### PR TITLE
Add docstrings and tests for qnl_engine

### DIFF
--- a/SPIRAL_OS/qnl_engine.py
+++ b/SPIRAL_OS/qnl_engine.py
@@ -97,6 +97,7 @@ TONE_MAP = {
 }
 
 def hex_to_qnl(hex_byte: str) -> dict:
+    """Return QNL glyph data for a given hex byte."""
     value = int(hex_byte, 16)
     frequency = 0.1 + (999 - 0.1) * (value / 255)
     amplitude = 0.1 + (1.0 - 0.1) * (value / 255)
@@ -122,6 +123,7 @@ def hex_to_qnl(hex_byte: str) -> dict:
     }
 
 def apply_psi_equation(amplitude: float, frequency: float, *, duration: float = 1.0, sample_rate: int = 44100, emotion: str = None) -> np.ndarray:
+    """Generate a waveform using the ψ equation."""
     t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
     phi = np.pi / 3 if emotion == "Longing" else 0.0
     alpha = 0.1
@@ -131,6 +133,7 @@ def apply_psi_equation(amplitude: float, frequency: float, *, duration: float = 
     return waveform
 
 def hex_to_song(hex_input: str, *, duration_per_byte: float = 1.0, sample_rate: int = 44100) -> Tuple[List[dict], np.ndarray]:
+    """Convert hex input into a list of phrases and a combined waveform."""
     if Path(hex_input).is_file():
         hex_string = Path(hex_input).read_text(encoding="utf-8").replace(" ", "").replace("\n", "")
     else:
@@ -160,6 +163,7 @@ def hex_to_song(hex_input: str, *, duration_per_byte: float = 1.0, sample_rate: 
     return phrases, full_wave
 
 def generate_qnl_metadata(phrases: List[dict]) -> dict:
+    """Build a metadata dictionary for a generated song."""
     return {
         "song_id": "QNL-SONGCORE-HEX-∞1.0",
         "theme": "A cosmic dance of longing and ignition, sung from data's heart.",
@@ -167,6 +171,7 @@ def generate_qnl_metadata(phrases: List[dict]) -> dict:
     }
 
 def main() -> None:
+    """CLI entry point for converting hex into a QNL song."""
     parser = argparse.ArgumentParser(description="Generate QNL song from hex")
     parser.add_argument("hex_input", help="Hex string or path to text file containing hex bytes")
     parser.add_argument("--wav", default="qnl_hex_song.wav", help="Output WAV file")

--- a/tests/test_qnl_engine.py
+++ b/tests/test_qnl_engine.py
@@ -1,0 +1,24 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import SPIRAL_OS.qnl_engine as qe
+
+
+def test_hex_to_qnl_basic():
+    data = qe.hex_to_qnl('ff')
+    assert data['glyph'] == '🕯✧'
+    assert data['emotion'] == 'Awakening'
+    assert data['tone'] == 'Flame-Hum'
+    assert data['amplitude'] == 1.0
+    assert data['frequency'] == 999.0
+
+
+def test_hex_to_song_sequence():
+    phrases, wave = qe.hex_to_song('0aFF', duration_per_byte=0.1)
+    assert [p['hex_byte'] for p in phrases] == ['0a', 'FF']
+    # Expect 0.2 seconds of audio at 44100 Hz
+    assert len(wave) == 8820
+    assert wave.dtype == np.int16
+    assert np.max(np.abs(wave)) <= 32767


### PR DESCRIPTION
## Summary
- document qnl_engine public functions
- add pytest tests for `hex_to_qnl` and `hex_to_song`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4dd12488832e9c7bc232650b4f74