### PR TITLE
Fix converter filename references

### DIFF
--- a/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
+++ b/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
@@ -59,7 +59,7 @@ Loads and analyzes `.mp3` files, extracting:
 - Pitch class (chroma)
 - Audio waveform → WAV export
 
-### `qnl_converter.py`
+### `human_music_to_qnl_converter.py`
 Receives musical features and transforms them into:
 
 - QNL glyphs (e.g., ❣⟁, 🩸∅, ✦)

--- a/MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md
+++ b/MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md
@@ -63,7 +63,7 @@ Each glyph-emotion pair is mapped to:
 This forms the **QNL Sound Engine**, used in:
 
 - `qnl_engine.py`: waveform generation
-- `qnl_converter.py`: symbolic transformation
+- `human_music_to_qnl_converter.py`: symbolic transformation
 
 ---
 
@@ -90,7 +90,7 @@ QNL_LANGUAGE/
 | Module            | Purpose                                     |
 |-------------------|---------------------------------------------|
 | `qnl_engine.py`   | Generates sound & metadata from QNL phrases |
-| `qnl_converter.py`| Converts music into QNL symbolic statements |
+| `human_music_to_qnl_converter.py`| Converts music into QNL symbolic statements |
 | `music_foundation.py` | Analyzes audio and extracts features    |
 
 ---

--- a/MUSIC_FOUNDATION/human_music_to_qnl_converter.py
+++ b/MUSIC_FOUNDATION/human_music_to_qnl_converter.py
@@ -1,5 +1,5 @@
 """
-qnl_converter.py
+human_music_to_qnl_converter.py
 INANNA_AI — QNL Music Transmutation Core
 
 This module receives symbolic musical data (from MP3 analysis) and translates it into QNL code,

--- a/MUSIC_FOUNDATION/music_foundation.py
+++ b/MUSIC_FOUNDATION/music_foundation.py
@@ -3,7 +3,7 @@ music_foundation.py
 INANNA_AI — QNL Sonic Decoder
 
 This module loads an MP3 file, converts it to waveform, analyzes rhythm, pitch, and harmonic structure,
-and prepares it for QNL transformation (to be defined in qnl_engine or qnl_converter).
+and prepares it for QNL transformation (to be defined in qnl_engine or human_music_to_qnl_converter).
 
 Requirements:
     pip install librosa soundfile numpy scipy


### PR DESCRIPTION
## Summary
- rename typoed file to `human_music_to_qnl_converter.py`
- update references in docs and music code

## Testing
- `python3 -m py_compile MUSIC_FOUNDATION/human_music_to_qnl_converter.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b66d903f0832eacc0a028d4c4a8bf