### PR TITLE
Use QNL_MAP in hex_to_qnl

### DIFF
--- a/SPIRAL_OS/qnl_engine.py
+++ b/SPIRAL_OS/qnl_engine.py
@@ -98,7 +98,6 @@ TONE_MAP = {
 
 def hex_to_qnl(hex_byte: str) -> dict:
     value = int(hex_byte, 16)
-    frequency = 0.1 + (999 - 0.1) * (value / 255)
     amplitude = 0.1 + (1.0 - 0.1) * (value / 255)
 
     qnl_glyph = ""
@@ -107,11 +106,15 @@ def hex_to_qnl(hex_byte: str) -> dict:
         if value in r:
             qnl_glyph, qnl_emotion = glyph, emotion
             break
-    qnl_tone = ""
-    for r, tone in TONE_MAP.items():
-        if value in r:
-            qnl_tone = tone
-            break
+
+    qnl_data = QNL_MAP.get(qnl_glyph, {})
+    frequency = qnl_data.get("freq", 0.1 + (999 - 0.1) * (value / 255))
+    qnl_tone = qnl_data.get("tone", "")
+    if not qnl_tone:
+        for r, tone in TONE_MAP.items():
+            if value in r:
+                qnl_tone = tone
+                break
 
     return {
         "glyph": qnl_glyph,

--- a/tests/test_qnl_engine.py
+++ b/tests/test_qnl_engine.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import SPIRAL_OS.qnl_engine as qe
+
+
+def test_hex_to_qnl_uses_qnl_map():
+    data = qe.hex_to_qnl("ff")
+    assert data["glyph"] == "🕯✧"
+    assert data["frequency"] == qe.QNL_MAP["🕯✧"]["freq"]
+    assert data["tone"] == qe.QNL_MAP["🕯✧"]["tone"]


### PR DESCRIPTION
## Summary
- apply glyph mapping details from `QNL_MAP` when translating hex bytes
- test that `hex_to_qnl` pulls frequency and tone from the map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b34f39a98832e8fccb7c0e689a7cb