### PR TITLE
Add directory creation in MusicInterpreter export_preview

### DIFF
--- a/MUSIC_FOUNDATION/music_foundation.py
+++ b/MUSIC_FOUNDATION/music_foundation.py
@@ -43,7 +43,13 @@ class MusicInterpreter:
         return avg_chroma
 
     def export_preview(self, output_path="music_preview.wav"):
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        """Save waveform as a standard WAV file for playback.
+
+        The directory for ``output_path`` is created if it does not exist.
+        """
+        directory = os.path.dirname(output_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
         sf.write(output_path, self.waveform, self.sample_rate)
         print(f"💾 Exported WAV preview to: {output_path}")
 


### PR DESCRIPTION
## Summary
- ensure `MusicInterpreter.export_preview` creates the output directory before writing the wave file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b864acc94832e8811d7a57f15c49d