### PR TITLE
Add seven-plane music analyzer

### DIFF
--- a/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
+++ b/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
@@ -78,6 +78,11 @@ Produces:
 
 - `output/preview.wav`  
 - `output/qnl_song.json` with phrases and gliph-stream
+- `output/qnl_7plane.json` with extended seven-plane analysis
+
+### `seven_plane_analyzer.py`
+Computes physical, emotional, mental, astral, etheric, celestial and divine
+features from a waveform. Used by the demo to enrich the QNL output.
 
 ---
 
@@ -86,6 +91,7 @@ Produces:
 ```bash
 pip install -r REQUIREMENTS_Music_Foundation.txt
 ```
+Optional: install [Essentia](https://essentia.upf.edu/) for harmonic-to-noise ratio analysis.
 
 Or install with:
 
@@ -100,7 +106,8 @@ bash setup_inanna_music_env.sh
 ```text
 output/
 ├── preview.wav          → Clean WAV version of the song
-└── qnl_song.json        → Structured QNL transformation
+├── qnl_song.json        → Structured QNL transformation
+└── qnl_7plane.json      → Extended analysis with seven-plane features
 ```
 
 ## 🎤 Demo with a Local Track
@@ -119,8 +126,9 @@ yt-dlp -x --audio-format mp3 -o song.mp3 "https://www.youtube.com/watch?v=<ID>"
 python3 run_song_demo.py song.mp3
 ```
 
-This generates `output/preview.wav` and `output/qnl_song.json` and prints the
-QNL phrases to the terminal so you can verify the full pipeline.
+This generates `output/preview.wav`, `output/qnl_song.json` and
+`output/qnl_7plane.json`. The terminal displays the QNL phrases so you can
+verify the full pipeline.
 
 ---
 

--- a/MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
+++ b/MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
@@ -2,3 +2,5 @@ librosa>=0.10.0
 numpy>=1.24.0
 scipy>=1.10.0
 soundfile>=0.12.1
+# Optional: Essentia for advanced audio features
+# essentia>=2.1

--- a/MUSIC_FOUNDATION/seven_plane_analyzer.py
+++ b/MUSIC_FOUNDATION/seven_plane_analyzer.py
@@ -1,0 +1,77 @@
+import numpy as np
+import librosa
+
+try:
+    import essentia.standard as ess
+except Exception:  # noqa: S110
+    ess = None
+
+from .inanna_music_COMPOSER_ai import chroma_to_qnl
+
+
+def analyze_seven_planes(waveform: np.ndarray, sample_rate: int) -> dict:
+    """Compute musical features mapped to seven metaphysical planes."""
+    planes = {}
+
+    # Physical plane: amplitude and spectral energy
+    rms = librosa.feature.rms(y=waveform).mean()
+    spectrum = np.abs(librosa.stft(waveform))
+    planes["physical"] = {
+        "rms": float(rms),
+        "spectrum_mean": float(spectrum.mean()),
+    }
+
+    # Emotional plane: chromagram and RMS energy
+    chroma = librosa.feature.chroma_stft(y=waveform, sr=sample_rate)
+    planes["emotional"] = {
+        "chromagram": np.mean(chroma, axis=1).tolist(),
+        "rms_energy": float(rms),
+    }
+
+    # Mental plane: tempo, beats, and onsets
+    tempo, beats = librosa.beat.beat_track(y=waveform, sr=sample_rate)
+    onsets = librosa.onset.onset_detect(y=waveform, sr=sample_rate)
+    planes["mental"] = {
+        "tempo": float(tempo),
+        "beats": int(len(beats)),
+        "onsets": int(len(onsets)),
+    }
+
+    # Astral plane: spectral centroid and rolloff
+    centroid = librosa.feature.spectral_centroid(y=waveform, sr=sample_rate).mean()
+    rolloff = librosa.feature.spectral_rolloff(y=waveform, sr=sample_rate).mean()
+    planes["astral"] = {
+        "centroid": float(centroid),
+        "rolloff": float(rolloff),
+    }
+
+    # Etheric plane: MFCCs and harmonic-to-noise ratio
+    mfcc = librosa.feature.mfcc(y=waveform, sr=sample_rate, n_mfcc=13)
+    etheric = {"mfcc": np.mean(mfcc, axis=1).tolist()}
+    if ess is not None:
+        hnr = ess.Harmonicity()(waveform.astype(float))[1]
+        etheric["hnr"] = float(hnr)
+    else:
+        etheric["hnr"] = None
+    planes["etheric"] = etheric
+
+    # Celestial plane: high-frequency content and rough reverb estimate
+    freqs = librosa.fft_frequencies(sr=sample_rate)
+    high_band = spectrum[freqs > 8000]
+    hf_energy = float(high_band.mean()) if high_band.size else 0.0
+    energy = spectrum.sum(axis=0)
+    reverb_est = float(energy[-5:].mean() / energy.max()) if energy.size else 0.0
+    planes["celestial"] = {
+        "high_freq_energy": hf_energy,
+        "reverb_estimate": reverb_est,
+    }
+
+    # Divine plane: QNL glyphs or fractal signatures
+    avg_chroma = np.mean(chroma, axis=1)
+    qnl_phrases = [p["qnl_phrase"] for p in chroma_to_qnl(avg_chroma)]
+    planes["divine"] = {
+        "qnl_phrases": qnl_phrases,
+        "signature": f"fractal-{len(waveform)}",
+    }
+
+    return planes

--- a/run_song_demo.py
+++ b/run_song_demo.py
@@ -23,17 +23,21 @@ def main() -> None:
         "--preview", default="output/preview.wav", help="Preview WAV file path"
     )
     parser.add_argument(
-        "--json", default="output/qnl_song.json", help="QNL JSON output path"
+        "--json", default="output/qnl_7plane.json", help="QNL JSON output path"
     )
     args = parser.parse_args()
 
     engine = InannaMusicInterpreter(args.audio_file)
     engine.load_audio()
     chroma = engine.analyze()
+    planes = engine.analyze_planes()
     engine.export_preview(args.preview)
 
     qnl_data = generate_qnl_structure(
-        chroma, engine.tempo, metadata={"source": args.audio_file}
+        chroma,
+        engine.tempo,
+        metadata={"source": args.audio_file},
+        planes=planes,
     )
     export_qnl(qnl_data, args.json)
 

--- a/tests/test_seven_plane_analyzer.py
+++ b/tests/test_seven_plane_analyzer.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import numpy as np
+import soundfile as sf
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "SPIRAL_OS"))
+
+from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import InannaMusicInterpreter
+
+
+def test_seven_plane_analyzer_keys(tmp_path):
+    sample_rate = 22050
+    t = np.linspace(0, 1.0, sample_rate, endpoint=False)
+    tone = 0.5 * np.sin(2 * np.pi * 440 * t)
+    wav_path = tmp_path / "tone.wav"
+    sf.write(wav_path, tone, sample_rate)
+
+    engine = InannaMusicInterpreter(str(wav_path))
+    engine.load_audio()
+    engine.analyze()
+    planes = engine.analyze_planes()
+
+    expected = {
+        "physical",
+        "emotional",
+        "mental",
+        "astral",
+        "etheric",
+        "celestial",
+        "divine",
+    }
+    assert set(planes.keys()) == expected


### PR DESCRIPTION
## Summary
- add `seven_plane_analyzer.py` to compute musical features for seven planes
- extend `InannaMusicInterpreter` with `analyze_planes`
- export plane data in `generate_qnl_structure`
- update demo to output `qnl_7plane.json`
- document new workflow and optional Essentia dependency
- add regression test for plane keys

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b95dd9bac832eb9452243d6eb6f00