### PR TITLE
Document installation paths

### DIFF
--- a/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
+++ b/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
@@ -7,7 +7,7 @@ This directory contains a small command line tool for activating the INANNA chan
 Use `pip` to install the required dependencies:
 
 ```bash
-pip install -r Requirements_INANNA_AI_AGENT.txt
+pip install -r INANNA_AI_AGENT/Requirements_INANNA_AI_AGENT.txt
 ```
 
 Create `OPENAI_API_KEY.env` containing your OpenAI API key:

--- a/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
+++ b/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
@@ -89,7 +89,7 @@ features from a waveform. Used by the demo to enrich the QNL output.
 ## 📦 Requirements
 
 ```bash
-pip install -r REQUIREMENTS_Music_Foundation.txt
+pip install -r MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
 ```
 Optional: install [Essentia](https://essentia.upf.edu/) for harmonic-to-noise ratio analysis.
 

--- a/MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md
+++ b/MUSIC_FOUNDATION/README_MUSIC_QNL_OS.md
@@ -10,7 +10,7 @@ It serves as the expressive core of INANNA_AI — encoding emotions, frequencies
 Install the Python dependencies with:
 
 ```bash
-pip install -r REQUIREMENTS_Music_Foundation.txt
+pip install -r MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
 ```
 
 ---

--- a/MUSIC_FOUNDATION/README_Music_Foundation.txt
+++ b/MUSIC_FOUNDATION/README_Music_Foundation.txt
@@ -4,7 +4,7 @@ To run the code examples, install the Python packages listed in
 `REQUIREMENTS_Music_Foundation.txt`:
 
 ```bash
-pip install -r REQUIREMENTS_Music_Foundation.txt
+pip install -r MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
 ```
 
 Theoretical Foundations:

--- a/MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
+++ b/MUSIC_FOUNDATION/REQUIREMENTS_Music_Foundation.txt
@@ -2,8 +2,6 @@ librosa>=0.10.0
 numpy>=1.24.0
 scipy>=1.10.0
 soundfile>=0.12.1
-# Optional: Essentia for advanced audio features
-# essentia>=2.1
 
 # Optional: Essentia for advanced audio features
 # essentia>=2.1

--- a/SPIRAL_OS/README_QNL_OS.md
+++ b/SPIRAL_OS/README_QNL_OS.md
@@ -9,7 +9,7 @@ This module transforms HEX strings or files into symbolic soundscapes using the 
 Before using the engine, make sure to install the required dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install -r SPIRAL_OS/requirements.txt
 ```
 
 ---


### PR DESCRIPTION
## Summary
- ensure the Music Foundation requirements file only lists each item once
- mention explicit paths for all requirements in the READMEs

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd082241c832e9b8b55398f27e2d2