### PR TITLE
Add audio steganography utilities

### DIFF
--- a/MUSIC_FOUNDATION/synthetic_stego.py
+++ b/MUSIC_FOUNDATION/synthetic_stego.py
@@ -1,0 +1,66 @@
+"""Simple LSB audio steganography utilities."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import soundfile as sf
+
+
+def _to_int16(data: np.ndarray) -> np.ndarray:
+    """Ensure waveform is 16-bit integer."""
+    if data.dtype == np.int16:
+        return data.copy()
+    return np.clip(data * 32767, -32768, 32767).astype(np.int16)
+
+
+def embed_data(input_wav: str, output_wav: str, message: str) -> None:
+    """Embed ``message`` inside ``input_wav`` and write to ``output_wav``."""
+    data, sr = sf.read(input_wav, always_2d=False)
+    samples = _to_int16(data)
+
+    msg_bytes = message.encode("utf-8")
+    length = len(msg_bytes)
+    header = length.to_bytes(4, "big")
+    payload = header + msg_bytes
+
+    bits = []
+    for byte in payload:
+        for i in range(7, -1, -1):
+            bits.append((byte >> i) & 1)
+
+    if len(bits) > samples.size:
+        raise ValueError("Message too large for audio file")
+
+    flat = samples.reshape(-1)
+    for i, bit in enumerate(bits):
+        flat[i] = (flat[i] & ~1) | bit
+    samples = flat.reshape(samples.shape)
+
+    sf.write(output_wav, samples, sr, subtype="PCM_16")
+
+
+def extract_data(wav_path: str) -> str:
+    """Extract a hidden message from ``wav_path``."""
+    data, _ = sf.read(wav_path, always_2d=False, dtype="int16")
+    flat = data.reshape(-1)
+    bits = [int(sample & 1) for sample in flat]
+
+    length = 0
+    for b in bits[:32]:
+        length = (length << 1) | b
+
+    needed = 32 + length * 8
+    if needed > len(bits):
+        raise ValueError("Incomplete hidden message")
+
+    msg_bits = bits[32:needed]
+    bytes_out = bytearray()
+    for i in range(length):
+        byte = 0
+        for j in range(8):
+            byte = (byte << 1) | msg_bits[i * 8 + j]
+        bytes_out.append(byte)
+
+    return bytes_out.decode("utf-8", errors="ignore")

--- a/SPIRAL_OS/seven_dimensional_music.py
+++ b/SPIRAL_OS/seven_dimensional_music.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - optional
     mido = None
 
 from SPIRAL_OS import qnl_engine
+from MUSIC_FOUNDATION.synthetic_stego import embed_data, extract_data
 
 
 def midi_to_wave(midi_path: str, sample_rate: int = 44100) -> Tuple[np.ndarray, int]:
@@ -120,6 +121,10 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("melody", help="Input melody (MIDI/WAV)")
     parser.add_argument("--payload", help="Optional hex data for a payload")
     parser.add_argument("--output", default="final_track.wav", help="Output WAV")
+    parser.add_argument(
+        "--secret",
+        help="Message to hide inside human_layer.wav and verify extraction",
+    )
     args = parser.parse_args(argv)
 
     wave, sr = load_melody(args.melody)
@@ -128,6 +133,12 @@ def main(argv: Optional[List[str]] = None) -> None:
     synthetic = build_synthetic_layer(wave, sr)
 
     sf.write("human_layer.wav", human, sr)
+    if args.secret:
+        embed_data("human_layer.wav", "human_layer.wav", args.secret)
+        recovered = extract_data("human_layer.wav")
+        print(f"Hidden message extracted: {recovered}")
+        human, _ = sf.read("human_layer.wav", always_2d=False)
+
     sf.write("crystal_layer.wav", crystal, sr)
     sf.write("synthetic_layer.wav", synthetic, sr)
 

--- a/tests/test_seven_dimensional_music.py
+++ b/tests/test_seven_dimensional_music.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from pathlib import Path
 import numpy as np
 import soundfile as sf
@@ -30,3 +31,33 @@ def test_cli_creates_final_track(tmp_path):
         sys.argv = argv_backup
 
     assert out.exists()
+
+def test_cli_secret_message(tmp_path):
+    sr = 44100
+    t = np.linspace(0, 0.25, sr // 4, endpoint=False)
+    tone = np.sin(2 * np.pi * 220 * t)
+    wav_path = tmp_path / "tone.wav"
+    sf.write(wav_path, tone, sr)
+
+    out = tmp_path / "final.wav"
+    secret = "hello"
+    argv_backup = sys.argv.copy()
+    cwd = os.getcwd()
+    sys.argv = [
+        "seven_dimensional_music.py",
+        str(wav_path),
+        "--output",
+        str(out),
+        "--secret",
+        secret,
+    ]
+    try:
+        os.chdir(tmp_path)
+        main()
+    finally:
+        os.chdir(cwd)
+        sys.argv = argv_backup
+
+    from MUSIC_FOUNDATION.synthetic_stego import extract_data
+    hidden = extract_data(tmp_path / "human_layer.wav")
+    assert hidden == secret

--- a/tests/test_synthetic_stego.py
+++ b/tests/test_synthetic_stego.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import numpy as np
+import soundfile as sf
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from MUSIC_FOUNDATION.synthetic_stego import embed_data, extract_data
+
+
+def test_embed_extract(tmp_path):
+    sr = 44100
+    data = np.zeros(sr, dtype=np.float32)
+    wav = tmp_path / "base.wav"
+    sf.write(wav, data, sr)
+
+    stego = tmp_path / "stego.wav"
+    embed_data(str(wav), str(stego), "hi")
+    assert extract_data(str(stego)) == "hi"


### PR DESCRIPTION
## Summary
- add `synthetic_stego.py` providing LSB audio steganography
- hide optional messages in the `human_layer.wav` output
- expose `--secret` CLI option to `seven_dimensional_music.py`
- test embedding/extracting data
- test CLI handling of the secret message

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be150c004832e9a409cddc655aaac