### PR TITLE
Add waveform mixing script and tests

### DIFF
--- a/SPIRAL_OS/mix_tracks.py
+++ b/SPIRAL_OS/mix_tracks.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Mix audio files into a normalized track.
+
+This script loads multiple audio files, sums them using NumPy, normalizes
+the amplitude, and writes ``final_track.wav`` in 16-bit PCM format at
+44.1 kHz. Optionally a short preview clip can be exported for quick
+listening.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Iterable, List
+
+import librosa
+import numpy as np
+import soundfile as sf
+
+
+def load_audio(path: str, sample_rate: int = 44100) -> np.ndarray:
+    """Return ``path`` as a mono waveform resampled to ``sample_rate``."""
+    data, _ = librosa.load(path, sr=sample_rate, mono=True)
+    return data.astype(np.float32)
+
+
+def mix_waveforms(waves: Iterable[np.ndarray]) -> np.ndarray:
+    """Sum and normalize a collection of waveforms."""
+    waves = list(waves)
+    if not waves:
+        return np.zeros(1, dtype=np.float32)
+    length = max(w.size for w in waves)
+    mixed = np.zeros(length, dtype=np.float32)
+    for w in waves:
+        if w.size < length:
+            w = np.pad(w, (0, length - w.size))
+        mixed += w
+    max_val = np.max(np.abs(mixed))
+    if max_val > 0:
+        mixed /= max_val
+    return mixed
+
+
+def export_wav(wave: np.ndarray, path: str, *, sample_rate: int = 44100) -> None:
+    """Write ``wave`` to ``path`` as 16-bit PCM at ``sample_rate``."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    sf.write(path, wave, sample_rate, subtype="PCM_16")
+
+
+def create_preview(
+    wave: np.ndarray,
+    path: str,
+    *,
+    sample_rate: int = 44100,
+    duration: float = 5.0,
+) -> None:
+    """Export the first ``duration`` seconds of ``wave`` to ``path``."""
+    preview = wave[: int(sample_rate * duration)]
+    export_wav(preview, path, sample_rate=sample_rate)
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Mix audio files")
+    parser.add_argument("files", nargs="+", help="Input audio files")
+    parser.add_argument("--output", default="final_track.wav", help="Output WAV")
+    parser.add_argument("--preview", help="Optional preview WAV path")
+    parser.add_argument(
+        "--preview-duration",
+        type=float,
+        default=5.0,
+        help="Preview length in seconds",
+    )
+    args = parser.parse_args(argv)
+
+    waves = [load_audio(f) for f in args.files]
+    mixed = mix_waveforms(waves)
+    export_wav(mixed, args.output)
+
+    if args.preview:
+        create_preview(
+            mixed,
+            args.preview,
+            duration=args.preview_duration,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mix_tracks.py
+++ b/tests/test_mix_tracks.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import numpy as np
+import soundfile as sf
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from SPIRAL_OS.mix_tracks import main
+
+
+def test_mix_tracks_cli(tmp_path):
+    sr = 44100
+    t = np.linspace(0, 0.25, sr // 4, endpoint=False)
+    tone1 = 0.5 * np.sin(2 * np.pi * 220 * t)
+    tone2 = 0.5 * np.sin(2 * np.pi * 440 * t)
+    wav1 = tmp_path / "tone1.wav"
+    wav2 = tmp_path / "tone2.wav"
+    sf.write(wav1, tone1, sr)
+    sf.write(wav2, tone2, sr)
+
+    out = tmp_path / "final.wav"
+    preview = tmp_path / "preview.wav"
+
+    argv_backup = sys.argv.copy()
+    sys.argv = [
+        "mix_tracks.py",
+        str(wav1),
+        str(wav2),
+        "--output",
+        str(out),
+        "--preview",
+        str(preview),
+        "--preview-duration",
+        "0.1",
+    ]
+    try:
+        main()
+    finally:
+        sys.argv = argv_backup
+
+    assert out.exists()
+    assert preview.exists()
+    info = sf.info(out)
+    assert info.samplerate == 44100
+    assert info.subtype.startswith("PCM_16")


### PR DESCRIPTION
## Summary
- implement `mix_tracks.py` to combine audio files with numpy and export 16‑bit WAV
- support optional preview clip
- add test to validate CLI behavior

## Testing
- `pip install -q -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686beb10a310832eab39a36548eeb529