### PR TITLE
Add roundtrip stego and analyzer tests

### DIFF
--- a/tests/test_seven_plane_analyzer.py
+++ b/tests/test_seven_plane_analyzer.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import InannaMusicInterpreter
+from MUSIC_FOUNDATION.seven_plane_analyzer import analyze_seven_planes
 
 
 def test_seven_plane_analyzer_keys(tmp_path):
@@ -20,6 +21,34 @@ def test_seven_plane_analyzer_keys(tmp_path):
     engine.load_audio()
     engine.analyze()
     planes = engine.analyze_planes()
+
+    expected = {
+        "physical",
+        "emotional",
+        "mental",
+        "astral",
+        "etheric",
+        "celestial",
+        "divine",
+    }
+    assert set(planes.keys()) == expected
+
+
+def test_analyze_seven_planes_mixed_waveform(tmp_path):
+    """analyze_seven_planes should return all seven plane keys."""
+    sr = 22050
+    t = np.linspace(0, 1.0, sr, endpoint=False)
+    mix = (
+        0.5 * np.sin(2 * np.pi * 220 * t)
+        + 0.25 * np.sin(2 * np.pi * 330 * t)
+        + 0.1 * np.random.randn(sr)
+    ).astype(np.float32)
+
+    wav = tmp_path / "mix.wav"
+    sf.write(wav, mix, sr)
+
+    data, _ = sf.read(wav)
+    planes = analyze_seven_planes(data, sr)
 
     expected = {
         "physical",

--- a/tests/test_synthetic_stego.py
+++ b/tests/test_synthetic_stego.py
@@ -18,3 +18,17 @@ def test_embed_extract(tmp_path):
     stego = tmp_path / "stego.wav"
     embed_data(str(wav), str(stego), "hi")
     assert extract_data(str(stego)) == "hi"
+
+
+def test_embed_extract_roundtrip(tmp_path):
+    """Embedding then extracting should return the original message."""
+    sr = 22050
+    data = np.random.randn(sr).astype(np.float32)
+    wav = tmp_path / "input.wav"
+    sf.write(wav, data, sr)
+
+    stego = tmp_path / "stego.wav"
+    message = "secret message 123"
+    embed_data(str(wav), str(stego), message)
+    extracted = extract_data(str(stego))
+    assert extracted == message


### PR DESCRIPTION
## Summary
- ensure embed/extract cycle works with a longer message
- check `analyze_seven_planes` directly on a mixed waveform

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bf0176c54832e9e7015de17991800