### PR TITLE
Fix preview export dir check

### DIFF
--- a/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
+++ b/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
@@ -77,7 +77,9 @@ class InannaMusicInterpreter:
 
     def export_preview(self, output_path="output/preview.wav"):
         """Save waveform as a standard WAV file for playback."""
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        dir_name = os.path.dirname(output_path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
         sf.write(output_path, self.waveform, self.sample_rate)
         print(f"💾 Exported audio preview: {output_path}")
 

--- a/tests/test_run_song_demo.py
+++ b/tests/test_run_song_demo.py
@@ -31,3 +31,26 @@ def test_run_song_demo(tmp_path):
 
     assert preview.exists()
     assert json_path.exists()
+
+
+def test_run_song_demo_preview_no_dir(tmp_path, monkeypatch):
+    audio_path = tmp_path / "short.wav"
+    audio_path.write_bytes(base64.b64decode(SHORT_WAV_BASE64))
+
+    argv_backup = sys.argv.copy()
+    sys.argv = [
+        "run_song_demo.py",
+        str(audio_path),
+        "--preview",
+        "preview.wav",
+        "--json",
+        str(tmp_path / "out.json"),
+    ]
+    monkeypatch.chdir(tmp_path)
+    try:
+        main()
+    finally:
+        sys.argv = argv_backup
+
+    assert (tmp_path / "preview.wav").exists()
+    assert (tmp_path / "out.json").exists()


### PR DESCRIPTION
## Summary
- avoid creating directories for preview when not necessary
- test preview path without directory

## Testing
- `pip install -q -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf541380c832ea78a0d3791c7cc25