### PR TITLE
Fix relative path handling in source_loader

### DIFF
--- a/INANNA_AI_AGENT/source_loader.py
+++ b/INANNA_AI_AGENT/source_loader.py
@@ -19,7 +19,10 @@ def load_config(config_file: Path = DEFAULT_CONFIG) -> List[Path]:
     paths = []
     for p in data.get("source_paths", []):
         try:
-            paths.append(Path(p))
+            path = Path(p)
+            if not path.is_absolute():
+                path = config_file.parent / path
+            paths.append(path)
         except Exception:
             continue
     return paths

--- a/tests/test_source_loader.py
+++ b/tests/test_source_loader.py
@@ -1,0 +1,29 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from INANNA_AI_AGENT import source_loader
+
+
+def test_load_config_relative_to_config(tmp_path, monkeypatch):
+    config_dir = tmp_path / "cfg"
+    text_dir = config_dir / "texts"
+    text_dir.mkdir(parents=True)
+    (text_dir / "a.md").write_text("hello", encoding="utf-8")
+
+    config = config_dir / "source_paths.json"
+    config.write_text(json.dumps({"source_paths": ["texts"]}), encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    paths = source_loader.load_config(config)
+    assert paths == [text_dir]
+
+    texts = source_loader.load_sources(config)
+    assert texts == {"a.md": "hello"}
+
+    files = source_loader.list_markdown_files(config)
+    assert files == [str(text_dir / "a.md")]


### PR DESCRIPTION
## Summary
- resolve relative paths in `load_config` against the config file
- add regression tests for loading config from a different CWD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2c670488832e896f48a3ef28641b