### PR TITLE
Add preprocessing benchmark script

### DIFF
--- a/INANNA_AI_AGENT/benchmark_preprocess.py
+++ b/INANNA_AI_AGENT/benchmark_preprocess.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Benchmark preprocessing of INANNA AI source texts."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from . import preprocess, source_loader
+
+
+def main() -> None:
+    """Load a subset of texts and time :func:`preprocess.preprocess_texts`."""
+    texts = source_loader.load_sources()
+    if not texts:
+        print("No texts found.")
+        return
+
+    subset_items = list(texts.items())[:5]
+    subset = dict(subset_items)
+
+    start = time.perf_counter()
+    preprocess.preprocess_texts(subset, cache_dir=Path("cache"))
+    duration = time.perf_counter() - start
+
+    print(f"Processed {len(subset)} texts in {duration:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/INANNA_AI_AGENT/source_loader.py
+++ b/INANNA_AI_AGENT/source_loader.py
@@ -19,7 +19,10 @@ def load_config(config_file: Path = DEFAULT_CONFIG) -> List[Path]:
     paths = []
     for p in data.get("source_paths", []):
         try:
-          
+            path = Path(p)
+            if not path.is_absolute():
+                path = (config_file.parent / path).resolve()
+            paths.append(path)
         except Exception:
             continue
     return paths

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,24 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from INANNA_AI_AGENT import benchmark_preprocess
+
+
+def test_benchmark_script_runs(tmp_path, monkeypatch, capsys):
+    text_dir = tmp_path / "INANNA_AI"
+    text_dir.mkdir()
+    (text_dir / "sample.md").write_text("hello world", encoding="utf-8")
+
+    config = tmp_path / "source_paths.json"
+    config.write_text(json.dumps({"source_paths": [str(text_dir)]}), encoding="utf-8")
+
+    monkeypatch.setattr(benchmark_preprocess.source_loader, "DEFAULT_CONFIG", config)
+    monkeypatch.chdir(tmp_path)
+
+    benchmark_preprocess.main()
+    out = capsys.readouterr().out
+    assert "Processed" in out


### PR DESCRIPTION
## Summary
- add `benchmark_preprocess.py` to quickly time preprocessing
- fix `source_loader.load_config` to resolve relative paths
- ensure benchmark script runs via new unit test

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3d5a91f0832eabcee77078e19e92