### PR TITLE
Add DeepSeek model downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 oracle_output/
 
 OPENAI_API_KEY.env
+INANNA_AI/models/
+INANNA_AI/secrets.env

--- a/INANNA_AI/secrets.env.example
+++ b/INANNA_AI/secrets.env.example
@@ -1,0 +1,3 @@
+# Copy this file to secrets.env and insert your HuggingFace token
+# Generate a token at https://huggingface.co/settings/tokens
+HF_TOKEN=""

--- a/INANNA_AI/src/download_model.py
+++ b/INANNA_AI/src/download_model.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+from huggingface_hub import snapshot_download
+
+
+def main() -> None:
+    token = os.getenv("HF_TOKEN")
+    if not token:
+        raise RuntimeError("HF_TOKEN environment variable not set")
+
+    target_dir = Path(__file__).resolve().parents[1] / "models" / "DeepSeek-R1"
+    snapshot_download(
+        repo_id="deepseek-ai/DeepSeek-R1",
+        token=token,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+    )
+    print(f"Model downloaded to {target_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore `INANNA_AI/models/` and secrets file
- provide example `secrets.env` with HuggingFace token placeholder
- add `download_model.py` utility to fetch `deepseek-ai/DeepSeek-R1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and others)*

------
https://chatgpt.com/codex/tasks/task_e_686c40b9b8cc832ebbbc680c34b279f0