### PR TITLE
Add huggingface packages

### DIFF
--- a/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
+++ b/INANNA_AI_AGENT/README_INANNA_AI_AGENT.md
@@ -10,6 +10,9 @@ Use `pip` to install the required dependencies:
 pip install -r INANNA_AI_AGENT/Requirements_INANNA_AI_AGENT.txt
 ```
 
+The requirements file now includes `huggingface_hub` and `accelerate`. It also
+ensures `transformers` and `torch` are installed automatically.
+
 Copy `OPENAI_API_KEY.env.example` to `OPENAI_API_KEY.env` and add your OpenAI API key:
 
 ```bash

--- a/INANNA_AI_AGENT/Requirements_INANNA_AI_AGENT.txt
+++ b/INANNA_AI_AGENT/Requirements_INANNA_AI_AGENT.txt
@@ -12,3 +12,5 @@ torchaudio
 pyaudio
 numpy
 sentence-transformers
+huggingface_hub
+accelerate


### PR DESCRIPTION
## Summary
- add `huggingface_hub` and `accelerate` to agent requirements
- mention new requirements in the agent README

## Testing
- `pip install -r tests/requirements.txt` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(failed to run due to missing numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686c465adc74832ea1c70126ef9d32aa