### PR TITLE
Add model downloader script

### DIFF
--- a/download_model.py
+++ b/download_model.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from huggingface_hub import snapshot_download
+from dotenv import load_dotenv
+
+
+def main() -> None:
+    """Download the DeepSeek-R1 model to the local models directory."""
+    load_dotenv()
+    token = os.getenv("HF_TOKEN")
+    if not token:
+        raise RuntimeError("HF_TOKEN environment variable not set")
+
+    target_dir = Path("INANNA_AI") / "models" / "DeepSeek-R1"
+    snapshot_download(
+        repo_id="deepseek-ai/DeepSeek-R1",
+        token=token,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+    )
+    print(f"Model downloaded to {target_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add root `download_model.py` for downloading the DeepSeek-R1 model using `huggingface_hub`
- load environment variables from `.env` if present

## Testing
- `pip install huggingface-hub python-dotenv`
- `pytest -q` *(fails: ModuleNotFoundError: soundfile, sentence_transformers, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686c4f623174832ea92c033ee066abb6