### PR TITLE
Add secrets env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ oracle_output/
 OPENAI_API_KEY.env
 INANNA_AI/models/
 INANNA_AI/secrets.env
+secrets.env

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -37,6 +37,7 @@ python INANNA_AI_AGENT/inanna_ai.py --hex 012345abcdef
 
 ## INANNA_AI DeepSeek-R1 Integration
 
-1. Set `HF_TOKEN` in `INANNA_AI/secrets.env`.
-2. Run `python INANNA_AI/src/download_model.py` to fetch the model.
+1. Copy `secrets.env.example` to `secrets.env` at the project root and set
+   `HF_TOKEN`.
+2. Run `python download_model.py` to fetch the model.
 3. Start chat via `python INANNA_AI_AGENT/inanna_ai.py chat` or `./run_inanna.sh`.

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,1 @@
+HF_TOKEN=<your token>


### PR DESCRIPTION
## Summary
- add secrets env template at project root
- ignore user secrets file
- document copying the template in the operator README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_686c52419e30832ea8a2450770a6155b