### PR TITLE
Add snapshot_download mock test

### DIFF
--- a/tests/test_download_model.py
+++ b/tests/test_download_model.py
@@ -1,0 +1,38 @@
+import sys
+import importlib
+from types import ModuleType
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_main_invokes_snapshot_download(monkeypatch):
+    # Provide dummy dotenv module
+    dummy_dotenv = ModuleType("dotenv")
+    dummy_dotenv.load_dotenv = lambda: None
+    monkeypatch.setitem(sys.modules, "dotenv", dummy_dotenv)
+
+    # Capture calls to snapshot_download
+    calls = {}
+    def dummy_snapshot_download(**kwargs):
+        calls.update(kwargs)
+    dummy_hf = ModuleType("huggingface_hub")
+    dummy_hf.snapshot_download = dummy_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", dummy_hf)
+
+    # Import the module under test
+    download_model = importlib.import_module("download_model")
+
+    # Set token env variable
+    monkeypatch.setenv("HF_TOKEN", "test-token")
+
+    download_model.main()
+
+    expected_dir = str(Path("INANNA_AI") / "models" / "DeepSeek-R1")
+    assert calls == {
+        "repo_id": "deepseek-ai/DeepSeek-R1",
+        "token": "test-token",
+        "local_dir": expected_dir,
+        "local_dir_use_symlinks": False,
+    }


### PR DESCRIPTION
## Summary
- add `tests/test_download_model.py` to verify `snapshot_download` parameters
- use dummy modules for `dotenv` and `huggingface_hub` to avoid network calls

## Testing
- `pytest tests/test_download_model.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5829102c832ea9719e0ed215f420