### PR TITLE
Fix relative path resolution in source_loader

### DIFF
--- a/INANNA_AI_AGENT/source_loader.py
+++ b/INANNA_AI_AGENT/source_loader.py
@@ -21,6 +21,8 @@ def load_config(config_file: Path = DEFAULT_CONFIG) -> List[Path]:
         try:
             path = Path(p)
             if not path.is_absolute():
+                # Resolve paths relative to the configuration file's location
+                path = (config_file.parent / path).resolve()
 
             paths.append(path)
         except Exception:


### PR DESCRIPTION
## Summary
- ensure relative paths in `load_config` resolve based on the config file location

## Testing
- `python -m py_compile INANNA_AI_AGENT/source_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686cff978e98832eaf1a33b2d22198da