### PR TITLE
Add model check to run_inanna.sh

### DIFF
--- a/run_inanna.sh
+++ b/run_inanna.sh
@@ -7,4 +7,12 @@ if [ -f "INANNA_AI/secrets.env" ]; then
     set +a
 fi
 
+# Check for required models before starting chat
+MODELS_DIR="INANNA_AI/models"
+if [ ! -d "$MODELS_DIR/DeepSeek-R1" ] && [ ! -d "$MODELS_DIR/gemma2" ]; then
+    echo "Required model files not found in $MODELS_DIR." >&2
+    echo "Run 'python download_models.py deepseek' or 'python download_models.py gemma2' before launching." >&2
+    exit 1
+fi
+
 python INANNA_AI_AGENT/inanna_ai.py chat


### PR DESCRIPTION
## Summary
- check `INANNA_AI/models` for DeepSeek-R1 or gemma2 models before running chat
- advise running `download_models.py` if models are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d2c6750d8832eafea2514c9dbca21