### PR TITLE
Add interaction DB storage

### DIFF
--- a/INANNA_AI_AGENT/inanna_ai.py
+++ b/INANNA_AI_AGENT/inanna_ai.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from . import source_loader, model
+from inanna_ai import db_storage
 from transformers import GenerationMixin
 
 WELCOME_MESSAGE = """
@@ -135,6 +136,7 @@ def chat_loop() -> None:
 
 def main() -> None:
     display_welcome_message()
+    db_storage.init_db()
 
     parser = argparse.ArgumentParser(description="INANNA activation agent")
     parser.add_argument("--activate", action="store_true", help="Recite birth chant")

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -5,4 +5,5 @@ __all__ = [
     "utils",
     "tts_coqui",
     "voice_evolution",
+    "db_storage",
 ]

--- a/inanna_ai/db_storage.py
+++ b/inanna_ai/db_storage.py
@@ -1,0 +1,82 @@
+"""SQLite helpers to store voice interactions."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+DB_PATH = Path(__file__).resolve().parent / "interactions.db"
+
+
+def init_db(db_path: Path = DB_PATH) -> None:
+    """Create the interactions table if it does not exist."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                transcript TEXT NOT NULL,
+                emotion TEXT NOT NULL,
+                response_path TEXT NOT NULL
+            )
+            """
+        )
+    conn.close()
+
+
+def save_interaction(
+    transcript: str,
+    emotion: str,
+    response_path: str,
+    *,
+    db_path: Path = DB_PATH,
+) -> None:
+    """Record a conversation entry in the database."""
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            "INSERT INTO interactions(timestamp, transcript, emotion, response_path) VALUES (?, ?, ?, ?)",
+            (datetime.utcnow().isoformat(), transcript, emotion, response_path),
+        )
+    conn.close()
+
+
+def fetch_interactions(limit: Optional[int] = None, db_path: Path = DB_PATH) -> List[Dict[str, str]]:
+    """Return saved interactions ordered from newest to oldest."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    query = "SELECT timestamp, transcript, emotion, response_path FROM interactions ORDER BY id DESC"
+    params = ()
+    if limit is not None:
+        query += " LIMIT ?"
+        params = (limit,)
+    cur.execute(query, params)
+    rows = cur.fetchall()
+    conn.close()
+    return [
+        {
+            "timestamp": row[0],
+            "transcript": row[1],
+            "emotion": row[2],
+            "response_path": row[3],
+        }
+        for row in rows
+    ]
+
+
+def last_interaction(db_path: Path = DB_PATH) -> Optional[Dict[str, str]]:
+    """Return the most recent interaction or ``None`` if database is empty."""
+    rows = fetch_interactions(limit=1, db_path=db_path)
+    return rows[0] if rows else None
+
+
+__all__ = [
+    "init_db",
+    "save_interaction",
+    "fetch_interactions",
+    "last_interaction",
+]


### PR DESCRIPTION
## Summary
- track interactions with a new sqlite db helper
- expose db functions in `inanna_ai`
- initialize the DB at startup of `inanna_ai` agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_686d5df20598832e93f2ade19ef9f860