### PR TITLE
Add VoiceEvolution class

### DIFF
--- a/inanna_ai/voice_evolution.py
+++ b/inanna_ai/voice_evolution.py
@@ -1,28 +1,42 @@
-"""Voice style parameters for Coqui TTS."""
+"""Helpers to evolve INANNA's vocal style."""
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict, Iterable
 
-VOICE_STYLES: Dict[str, Dict[str, float]] = {
+DEFAULT_VOICE_STYLES: Dict[str, Dict[str, float]] = {
     "neutral": {"speed": 1.0, "pitch": 0.0},
     "calm": {"speed": 0.9, "pitch": -1.0},
     "excited": {"speed": 1.1, "pitch": 1.0},
 }
 
 
+class VoiceEvolution:
+    """Manage voice style parameters and allow future fine-tuning."""
+
+    def __init__(self, styles: Dict[str, Dict[str, float]] | None = None) -> None:
+        self.styles: Dict[str, Dict[str, float]] = (
+            {k: v.copy() for k, v in (styles or DEFAULT_VOICE_STYLES).items()}
+        )
+
+    def get_params(self, emotion: str) -> Dict[str, float]:
+        """Return style parameters for ``emotion`` label."""
+        return self.styles.get(emotion.lower(), self.styles["neutral"])
+
+    def update_from_history(self, history: Iterable[Dict[str, Any]]) -> None:
+        """Placeholder for future style adaptation logic."""
+        _ = history
+
+    def reset(self) -> None:
+        """Reset styles to the default values."""
+        self.styles = {k: v.copy() for k, v in DEFAULT_VOICE_STYLES.items()}
+
+
+_evolver = VoiceEvolution()
+
+
 def get_voice_params(emotion: str) -> Dict[str, float]:
-    """Return style parameters for ``emotion``.
+    """Return parameters from the default :class:`VoiceEvolution`."""
+    return _evolver.get_params(emotion)
 
-    Parameters
-    ----------
-    emotion:
-        Target emotion label such as ``"neutral"`` or ``"excited"``.
 
-    Returns
-    -------
-    Dict[str, float]
-        Mapping with ``speed`` and ``pitch`` entries.
-    """
-    return VOICE_STYLES.get(emotion.lower(), VOICE_STYLES["neutral"])
-
-__all__ = ["get_voice_params", "VOICE_STYLES"]
+__all__ = ["VoiceEvolution", "get_voice_params", "DEFAULT_VOICE_STYLES"]


### PR DESCRIPTION
## Summary
- expand `inanna_ai/voice_evolution` with `VoiceEvolution` class
- keep helper `get_voice_params` but now via a default `VoiceEvolution`

## Testing
- `python -m py_compile inanna_ai/voice_evolution.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d5fb2d8c4832ea0dfa28051ac11ae