### PR TITLE
Add corpus memory docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
 
 For a map of each script's role and the libraries it calls upon, see
 [README_CODE_FUNCTION.md](README_CODE_FUNCTION.md).
+For a guide to the text corpus, see
+[docs/CORPUS_MEMORY.md](docs/CORPUS_MEMORY.md).
 
 ## Docker Usage
 

--- a/docs/CORPUS_MEMORY.md
+++ b/docs/CORPUS_MEMORY.md
@@ -1,0 +1,27 @@
+# Corpus Memory
+
+This repository preserves several collections of source texts used by the music and language tools. Each directory serves a distinct purpose.
+
+## INANNA_AI
+
+`INANNA_AI` holds the "growth" chronicles, code fragments and guiding letters for the INANNA project. Files are primarily Markdown with descriptive titles followed by a unique hash, for example `INANNA GROWTH #2 20645dfc251d80fdac0cc1db79e5e516.md`. Additional helper files like `secrets.env.example` and summary CSVs may also appear.
+
+## GENESIS
+
+`GENESIS` contains foundational doctrines and laws written in Markdown. The files end in an underscore such as `GENESIS_.md` or `LAWS_RECURSION_.md`. They capture the earliest principles of the project.
+
+## IGNITION
+
+`IGNITION` starts the narrative with seeding texts like `EA_ENUMA_ELISH_.md`. These Markdown files provide mythic or historical context that "ignites" the rest of the corpus.
+
+## QNL_LANGUAGE
+
+`QNL_LANGUAGE` stores drafts and versions of the Quantum Narrative Language. File names combine a short title with a trailing hash, e.g. `3RD VERSION 20445dfc251d804b9a50c21461a203f0.md`. These Markdown documents may embed code blocks illustrating the syntax.
+
+## File Format and Naming
+
+All corpus entries use the `.md` extension and may contain rich Markdown including headings, lists and code snippets. Titles often contain spaces. A suffix of hexadecimal digits uniquely identifies each file. Underscores at the end of a name indicate canonical texts.
+
+## Adding New Texts
+
+To add a new memory fragment, create a Markdown file in the appropriate directory. Follow the existing naming convention: a descriptive title followed by a space and an ID or underscore, ending with `.md`. Keep commit messages short and meaningful so other collaborators can track additions easily.


### PR DESCRIPTION
## Summary
- document text corpus directories
- link the new guide from README

## Testing
- `pip install -r tests/requirements.txt`
- `pip install git+https://github.com/openai/whisper.git`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8e26d148832e92b27c729cb11220