### PR TITLE
Add corpus memory search functionality

### DIFF
--- a/inanna_ai/corpus_memory.py
+++ b/inanna_ai/corpus_memory.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Simple embedding-based search across the corpus memory directories."""
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+# Location of the repository root
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Default memory folders relative to the repo root
+MEMORY_DIRS: List[Path] = [
+    _REPO_ROOT / "INANNA_AI",
+    _REPO_ROOT / "GENESIS",
+    _REPO_ROOT / "IGNITION",
+    _REPO_ROOT / "QNL_LANGUAGE",
+]
+
+
+def scan_memory(dirs: Iterable[Path] = MEMORY_DIRS) -> Dict[str, str]:
+    """Return mapping of file path to text for Markdown files in ``dirs``."""
+    texts: Dict[str, str] = {}
+    for directory in dirs:
+        if not directory.exists():
+            continue
+        for fp in sorted(directory.glob("*.md")):
+            try:
+                texts[str(fp)] = fp.read_text(encoding="utf-8")
+            except Exception:
+                continue
+    return texts
+
+
+def _build_embeddings(texts: List[str], model: SentenceTransformer) -> np.ndarray:
+    """Return embeddings for ``texts`` using ``model``."""
+    return np.asarray(model.encode(texts, convert_to_numpy=True))
+
+
+def search_corpus(
+    query: str,
+    *,
+    top_k: int = 3,
+    dirs: Iterable[Path] | None = None,
+    model_name: str = "all-MiniLM-L6-v2",
+) -> List[Tuple[str, str]]:
+    """Return ``top_k`` matching files and snippets for ``query``."""
+    if dirs is None:
+        dirs = MEMORY_DIRS
+
+    texts = scan_memory(dirs)
+    if not texts:
+        return []
+
+    model = SentenceTransformer(model_name)
+    file_paths = list(texts.keys())
+    corpus_emb = _build_embeddings(list(texts.values()), model)
+    query_emb = _build_embeddings([query], model)[0]
+
+    norms = np.linalg.norm(corpus_emb, axis=1) * np.linalg.norm(query_emb)
+    sims = (corpus_emb @ query_emb) / (norms + 1e-8)
+    top_idx = sims.argsort()[::-1][:top_k]
+
+    results: List[Tuple[str, str]] = []
+    for idx in top_idx:
+        path = file_paths[idx]
+        snippet = texts[path].splitlines()[0][:200]
+        results.append((path, snippet))
+    return results
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Search corpus memory")
+    parser.add_argument("--search", required=True, help="Query string")
+    parser.add_argument("--top", type=int, default=3, help="Number of matches")
+    args = parser.parse_args(argv)
+
+    results = search_corpus(args.search, top_k=args.top)
+    for path, snippet in results:
+        print(f"{path}: {snippet}")
+
+
+if __name__ == "__main__":
+    main()
+
+__all__ = ["scan_memory", "search_corpus", "main", "MEMORY_DIRS"]

--- a/tests/test_corpus_memory.py
+++ b/tests/test_corpus_memory.py
@@ -1,0 +1,43 @@
+import sys
+import numpy as np
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import corpus_memory
+
+
+def test_cli_search(tmp_path, monkeypatch, capsys):
+    dirs = []
+    for name in ["INANNA_AI", "GENESIS", "IGNITION", "QNL_LANGUAGE"]:
+        d = tmp_path / name
+        d.mkdir()
+        dirs.append(d)
+    (dirs[1] / "found.md").write_text("A magical unicorn appears.", encoding="utf-8")
+    (dirs[0] / "other.md").write_text("Nothing to see here.", encoding="utf-8")
+
+    monkeypatch.setattr(corpus_memory, "MEMORY_DIRS", dirs)
+
+    class DummyModel:
+        def __init__(self, name: str) -> None:
+            pass
+
+        def encode(self, texts, convert_to_numpy=True):
+            def vec(t):
+                return np.array([t.lower().count("unicorn")], dtype=float)
+            if isinstance(texts, list):
+                return np.array([vec(t) for t in texts])
+            return vec(texts)
+
+    monkeypatch.setattr(corpus_memory, "SentenceTransformer", lambda name: DummyModel(name))
+
+    argv_backup = sys.argv.copy()
+    sys.argv = ["corpus_memory", "--search", "unicorn", "--top", "1"]
+    try:
+        corpus_memory.main()
+    finally:
+        sys.argv = argv_backup
+
+    out = capsys.readouterr().out.lower()
+    assert "found.md" in out


### PR DESCRIPTION
## Summary
- create `corpus_memory` module for embedding-based search of Markdown texts
- expose CLI `python -m inanna_ai.corpus_memory --search` for quick lookup
- add unit test covering the CLI

## Testing
- `pytest tests/test_corpus_memory.py::test_cli_search -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_686d9009ccd0832e956d6e9b6fed4a9e