### PR TITLE
Add streaming listening engine

### DIFF
--- a/inanna_ai/README.md
+++ b/inanna_ai/README.md
@@ -11,7 +11,8 @@ This package provides a lightweight set of utilities for building a voice interf
 - `voice_evolution.py` – Manages parameters that control speaking style and can adapt them over time.
 - `tts_coqui.py` – Generates speech using Coqui TTS.  When the library is not available it synthesizes a simple sine wave placeholder.
 - `db_storage.py` – Stores transcripts and generated responses in a SQLite database for later inspection.
-- `main.py` – Command line interface that records microphone input, runs the processing steps above and plays or saves the response.
+- `listening_engine.py` – Streams microphone audio and extracts real-time emotion and environment states.
+- `main.py` – Command line interface that records microphone input using the listening engine, runs the processing steps above and plays or saves the response.
 
 ## Installation
 

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "tts_coqui",
     "voice_evolution",
     "db_storage",
+    "listening_engine",
 ]

--- a/inanna_ai/listening_engine.py
+++ b/inanna_ai/listening_engine.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Real-time microphone listening with basic feature extraction."""
+
+import logging
+import tempfile
+from pathlib import Path
+from queue import Queue, Empty
+from typing import Dict, Generator, Optional, Tuple
+
+import numpy as np
+import librosa
+
+from . import utils
+
+try:
+    import sounddevice as sd
+except Exception:  # pragma: no cover - optional dependency
+    sd = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_features(wave: np.ndarray, sr: int) -> Dict[str, float]:
+    """Return pitch, tempo, emotion and classification for ``wave``."""
+    if len(wave) == 0:
+        return {"emotion": "neutral", "pitch": 0.0, "tempo": 0.0, "classification": "silence"}
+
+    f0 = librosa.yin(wave, librosa.note_to_hz("C2"), librosa.note_to_hz("C7"), sr=sr)
+    pitch = float(np.nanmean(f0))
+    tempo, _ = librosa.beat.beat_track(y=wave, sr=sr)
+    tempo = float(np.atleast_1d(tempo)[0])
+
+    energy = float(np.mean(wave ** 2))
+    classification = "silence"
+    if energy > 1e-4:
+        classification = "speech" if 80 <= pitch <= 300 else "noise"
+
+    emotion = "neutral"
+    if pitch > 180 and tempo > 120:
+        emotion = "excited"
+    elif pitch < 120 and tempo < 90:
+        emotion = "calm"
+
+    return {
+        "emotion": emotion,
+        "pitch": round(pitch, 2),
+        "tempo": round(tempo, 2),
+        "classification": classification,
+    }
+
+
+class ListeningEngine:
+    """Stream audio from the microphone and yield analysis for each chunk."""
+
+    def __init__(self, sr: int = 44100, chunk_duration: float = 0.5) -> None:
+        if sd is None:
+            raise RuntimeError("sounddevice library not installed")
+        self.sr = sr
+        self.chunk_size = int(sr * chunk_duration)
+        self._queue: "Queue[np.ndarray]" = Queue()
+        self._stream: Optional[sd.InputStream] = None
+
+    def _callback(self, indata: np.ndarray, frames: int, time, status) -> None:  # pragma: no cover - external callback
+        if status:
+            logger.warning("InputStream status: %s", status)
+        self._queue.put(indata[:, 0].copy())
+
+    def __enter__(self) -> "ListeningEngine":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        """Start streaming from the microphone."""
+        if self._stream is not None:
+            return
+        self._stream = sd.InputStream(
+            samplerate=self.sr,
+            channels=1,
+            blocksize=self.chunk_size,
+            callback=self._callback,
+        )
+        self._stream.start()
+        logger.info("Listening engine started")
+
+    def stop(self) -> None:
+        """Stop the microphone stream."""
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+            logger.info("Listening engine stopped")
+
+    def stream_chunks(self, duration: Optional[float] = None) -> Generator[Tuple[np.ndarray, Dict[str, float]], None, None]:
+        """Yield (waveform, features) tuples for each audio chunk."""
+        if self._stream is None:
+            self.start()
+        total_frames = int(duration * self.sr) if duration else None
+        frames_read = 0
+        while total_frames is None or frames_read < total_frames:
+            try:
+                chunk = self._queue.get(timeout=duration)
+            except Empty:
+                continue
+            frames_read += len(chunk)
+            features = _extract_features(chunk, self.sr)
+            yield chunk, features
+            if total_frames is not None and frames_read >= total_frames:
+                break
+
+    def record(self, duration: float) -> Tuple[str, Dict[str, float]]:
+        """Capture ``duration`` seconds of audio and return file path and last state."""
+        chunks = []
+        last_state: Dict[str, float] = {}
+        for chunk, state in self.stream_chunks(duration):
+            chunks.append(chunk)
+            last_state = state
+        wave = np.concatenate(chunks) if chunks else np.array([], dtype=np.float32)
+        path = Path(tempfile.gettempdir()) / "inanna_stream.wav"
+        utils.save_wav(wave.astype(np.float32), str(path), sr=self.sr)
+        return str(path), last_state
+
+
+__all__ = ["ListeningEngine"]
+

--- a/inanna_ai/main.py
+++ b/inanna_ai/main.py
@@ -2,30 +2,17 @@ from __future__ import annotations
 
 """Command line interface for recording and responding with INANNA AI."""
 
-from pathlib import Path
 import argparse
-import tempfile
 import logging
 
-from . import utils, stt_whisper, emotion_analysis, tts_coqui, db_storage
-
-try:
-    import sounddevice as sd
-except Exception:  # pragma: no cover - optional dependency
-    sd = None
-
-
-def record_audio(duration: float = 3.0, sr: int = 44100) -> str:
-    """Record microphone input and return path to a temporary WAV file."""
-    if sd is None:
-        raise RuntimeError("sounddevice library not installed")
-    logging.info("Recording %.1f seconds of audio", duration)
-    wave = sd.rec(int(duration * sr), samplerate=sr, channels=1, dtype="float32")
-    sd.wait()
-    wave = wave[:, 0]
-    path = Path(tempfile.gettempdir()) / "inanna_recording.wav"
-    utils.save_wav(wave, str(path), sr=sr)
-    return str(path)
+from . import (
+    utils,
+    stt_whisper,
+    emotion_analysis,
+    tts_coqui,
+    db_storage,
+    listening_engine,
+)
 
 
 def generate_response(transcript: str, emotion: str) -> str:
@@ -42,9 +29,11 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--duration", type=float, default=3.0, help="Recording length in seconds")
     args = parser.parse_args(argv)
 
-    audio_path = record_audio(args.duration)
+    engine = listening_engine.ListeningEngine()
+    audio_path, emotion_info = engine.record(args.duration)
     transcript = stt_whisper.transcribe_audio(audio_path)
-    emotion_info = emotion_analysis.analyze_audio_emotion(audio_path)
+    if not emotion_info:
+        emotion_info = emotion_analysis.analyze_audio_emotion(audio_path)
     emotion = emotion_info["emotion"]
 
     response_text = generate_response(transcript, emotion)

--- a/tests/test_audio_tools.py
+++ b/tests/test_audio_tools.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from inanna_ai import stt_whisper, emotion_analysis
+from inanna_ai.listening_engine import _extract_features
 from tests.data.test1_wav_base64 import TEST1_WAV_BASE64
 
 
@@ -37,3 +38,12 @@ def test_analyze_audio_emotion(tmp_path):
     audio_path = _write_audio(tmp_path)
     info = emotion_analysis.analyze_audio_emotion(str(audio_path))
     assert set(info) == {"emotion", "pitch", "tempo"}
+
+
+def test_extract_features(tmp_path):
+    audio_path = _write_audio(tmp_path)
+    import librosa
+
+    wave, sr = librosa.load(audio_path, sr=None, mono=True)
+    info = _extract_features(wave, sr)
+    assert set(info) == {"emotion", "pitch", "tempo", "classification"}


### PR DESCRIPTION
## Summary
- implement `listening_engine.py` for real-time audio capture
- expose new engine in `__init__`
- update CLI to use the streaming engine
- document listening engine in README
- test audio feature extraction

## Testing
- `pip install -q -r tests/requirements.txt` *(fails: ModuleNotFoundError: numpy)*
- `pytest -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686d97f1eb1c832e8aa7e4d6b42214c3