### PR TITLE
Improve audio emotion analysis

### DIFF
--- a/inanna_ai/README.md
+++ b/inanna_ai/README.md
@@ -7,7 +7,7 @@ This package provides a lightweight set of utilities for building a voice interf
 - `config.py` – Holds configuration constants such as model paths and ritual text used across the toolkit.
 - `utils.py` – Basic helpers for loading and saving audio files and configuring logging.
 - `stt_whisper.py` – Thin wrapper around OpenAI Whisper that downloads and runs the speech‑to‑text model.
-- `emotion_analysis.py` – Estimates a rough emotional label (excited, calm or neutral) using Librosa pitch and tempo analysis.
+- `emotion_analysis.py` – Estimates a rough emotional label (joy, stress, fear and others) using Librosa pitch, tempo and energy analysis.
 - `voice_evolution.py` – Manages parameters that control speaking style and can adapt them over time.
 - `tts_coqui.py` – Generates speech using Coqui TTS.  When the library is not available it synthesizes a simple sine wave placeholder.
 - `db_storage.py` – Stores transcripts and generated responses in a SQLite database for later inspection.

--- a/inanna_ai/listening_engine.py
+++ b/inanna_ai/listening_engine.py
@@ -27,7 +27,12 @@ def _extract_features(wave: np.ndarray, sr: int) -> Dict[str, float]:
     if len(wave) == 0:
         return {"emotion": "neutral", "pitch": 0.0, "tempo": 0.0, "classification": "silence"}
 
-    f0 = librosa.yin(wave, librosa.note_to_hz("C2"), librosa.note_to_hz("C7"), sr=sr)
+    f0 = librosa.yin(
+        wave,
+        fmin=librosa.note_to_hz("C2"),
+        fmax=librosa.note_to_hz("C7"),
+        sr=sr,
+    )
     pitch = float(np.nanmean(f0))
     tempo, _ = librosa.beat.beat_track(y=wave, sr=sr)
     tempo = float(np.atleast_1d(tempo)[0])
@@ -37,8 +42,15 @@ def _extract_features(wave: np.ndarray, sr: int) -> Dict[str, float]:
     if energy > 1e-4:
         classification = "speech" if 80 <= pitch <= 300 else "noise"
 
+    amp = float(np.mean(np.abs(wave)))
     emotion = "neutral"
-    if pitch > 180 and tempo > 120:
+    if amp > 0.4:
+        emotion = "stress"
+    elif pitch > 400 and amp < 0.1:
+        emotion = "fear"
+    elif pitch > 300 and amp > 0.2:
+        emotion = "joy"
+    elif pitch > 180 and tempo > 120:
         emotion = "excited"
     elif pitch < 120 and tempo < 90:
         emotion = "calm"


### PR DESCRIPTION
## Summary
- expand emotion detection with stress, fear and joy labels
- map emotions to Jungian archetypes
- expose helper functions for archetype and emotional weight queries
- update listening engine to use new categories
- extend unit tests for new mapping

## Testing
- `pip install -q -r tests/requirements.txt`
- `pip install -q openai-whisper`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d997fbeb4832eb2ec1a3fc333f459