### PR TITLE
Extend emotion mapping

### DIFF
--- a/inanna_ai/emotion_analysis.py
+++ b/inanna_ai/emotion_analysis.py
@@ -9,6 +9,7 @@ EMOTION_ARCHETYPES = {
     "joy": "Jester",
     "stress": "Warrior",
     "fear": "Orphan",
+    "sad": "Caregiver",
     "excited": "Hero",
     "calm": "Sage",
     "neutral": "Everyman",
@@ -19,6 +20,7 @@ EMOTION_WEIGHT = {
     "joy": 1.0,
     "stress": 0.8,
     "fear": 0.8,
+    "sad": 0.7,
     "excited": 0.6,
     "calm": 0.4,
     "neutral": 0.2,
@@ -67,6 +69,8 @@ def analyze_audio_emotion(audio_path: str) -> Dict[str, Any]:
         emotion = "fear"
     elif pitch > 300 and energy > 0.2:
         emotion = "joy"
+    elif pitch < 160 and energy < 0.1:
+        emotion = "sad"
     elif pitch > 180 and tempo > 120:
         emotion = "excited"
     elif pitch < 120 and tempo < 90:

--- a/inanna_ai/listening_engine.py
+++ b/inanna_ai/listening_engine.py
@@ -50,6 +50,8 @@ def _extract_features(wave: np.ndarray, sr: int) -> Dict[str, float]:
         emotion = "fear"
     elif pitch > 300 and amp > 0.2:
         emotion = "joy"
+    elif pitch < 160 and amp < 0.1:
+        emotion = "sad"
     elif pitch > 180 and tempo > 120:
         emotion = "excited"
     elif pitch < 120 and tempo < 90:

--- a/tests/test_audio_tools.py
+++ b/tests/test_audio_tools.py
@@ -82,3 +82,8 @@ def test_emotion_archetype_mapping(tmp_path):
     info = emotion_analysis.analyze_audio_emotion(str(fear_path))
     assert info["emotion"] == "fear"
     assert emotion_analysis.get_current_archetype() == "Orphan"
+
+    sad_path = _save_sine(tmp_path, 130.0, 0.05)
+    info = emotion_analysis.analyze_audio_emotion(str(sad_path))
+    assert info["emotion"] == "sad"
+    assert emotion_analysis.get_current_archetype() == "Caregiver"


### PR DESCRIPTION
## Summary
- add `sad` label to emotion analysis and listening engine
- map the new label to the `Caregiver` archetype
- update unit tests to cover the new mapping

## Testing
- `pytest tests/test_audio_tools.py::test_emotion_archetype_mapping -q`

------
https://chatgpt.com/codex/tasks/task_e_686dad0e2058832ea1303aeab0391e0d