### PR TITLE
Integrate audio context into dialogue manager

### DIFF
--- a/inanna_ai/README.md
+++ b/inanna_ai/README.md
@@ -12,6 +12,8 @@ This package provides a lightweight set of utilities for building a voice interf
 - `tts_coqui.py` – Generates speech using Coqui TTS.  When the library is not available it synthesizes a simple sine wave placeholder.
 - `db_storage.py` – Stores transcripts and generated responses in a SQLite database for later inspection.
 - `listening_engine.py` – Streams microphone audio and extracts real-time emotion and environment states.
+- `response_manager.py` – Chooses a Surface/Deep/Umbra/Albedo reply by
+  combining the transcript with the detected emotion and environment.
 - `main.py` – Command line interface that records microphone input using the listening engine, runs the processing steps above and plays or saves the response.
 
 ## Installation
@@ -56,6 +58,11 @@ python -m inanna_ai.main --duration 5
 The emotion analysis module maps each label to a Jungian archetype (for
 example `joy` → `Jester` and `calm` → `Sage`).  These mappings are defined in
 `emotion_analysis.EMOTION_ARCHETYPES`.
+
+The `response_manager.ResponseManager` pairs this emotional state and the
+environment classification with your transcript. It queries the corpus memory
+for related snippets and returns a reply tagged with one of the four cores
+(Surface, Deep, Umbra, Albedo).
 
 ## Extending the Codex
 

--- a/inanna_ai/response_manager.py
+++ b/inanna_ai/response_manager.py
@@ -7,16 +7,26 @@ from typing import Dict
 from . import corpus_memory
 
 
+# Reply templates for each core.  ``emotion`` and ``classification`` are inserted
+# to blend audio cues with the textual input.
 CORE_TEMPLATES = {
-    "surface": "[Surface] {snippet} You said: '{text}'",
-    "deep": "[Deep] {snippet} Your words carry depth: '{text}'",
-    "umbra": "[Umbra] {snippet} Shadows echo: '{text}'",
-    "albedo": "[Albedo] {snippet} Reflecting: '{text}'",
+    "surface": "[Surface] {snippet} ({emotion}/{classification}) You said: '{text}'",
+    "deep": "[Deep] {snippet} ({emotion}/{classification}) Your words carry depth: '{text}'",
+    "umbra": "[Umbra] {snippet} ({emotion}/{classification}) Shadows echo: '{text}'",
+    "albedo": "[Albedo] {snippet} ({emotion}/{classification}) Reflecting: '{text}'",
 }
 
 
 class ResponseManager:
-    """Select replies based on emotional and environmental cues."""
+    """Select replies based on emotional and environmental cues.
+
+    The manager receives the emotional ``state`` and ``classification`` detected
+    by :class:`listening_engine.ListeningEngine` and chooses one of the
+    Surface/Deep/Umbra/Albedo cores. A search against the CORPUS MEMORY is
+    performed using :func:`corpus_memory.search_corpus` with a query that blends
+    the transcript, emotion and classification.  The chosen template then
+    incorporates the snippet and audio context into the final text reply.
+    """
 
     def choose_core(self, emotion: str, classification: str) -> str:
         """Return core name for the given emotion and environment."""
@@ -31,7 +41,21 @@ class ResponseManager:
         return "deep"
 
     def generate_reply(self, text: str, info: Dict[str, str]) -> str:
-        """Generate a text reply blending ``info`` with ``text``."""
+        """Generate a text reply blending audio and textual context.
+
+        Parameters
+        ----------
+        text:
+            The transcript recognized from speech.
+        info:
+            Output of :class:`listening_engine.ListeningEngine` containing at
+            least ``emotion`` and ``classification`` keys.
+
+        Returns
+        -------
+        str
+            The rendered reply text including a snippet from CORPUS MEMORY.
+        """
         emotion = info.get("emotion", "neutral")
         classification = info.get("classification", "")
         query = f"{text} {emotion} {classification}".strip()
@@ -39,7 +63,12 @@ class ResponseManager:
         snippet = snippets[0][1] if snippets else ""
         core = self.choose_core(emotion, classification)
         template = CORE_TEMPLATES.get(core, CORE_TEMPLATES["surface"])
-        return template.format(snippet=snippet, text=text, emotion=emotion)
+        return template.format(
+            snippet=snippet,
+            text=text,
+            emotion=emotion,
+            classification=classification,
+        )
 
 
 __all__ = ["ResponseManager", "CORE_TEMPLATES"]

--- a/tests/test_response_manager.py
+++ b/tests/test_response_manager.py
@@ -21,3 +21,6 @@ def test_generate_reply_queries_corpus(monkeypatch):
     reply = mgr.generate_reply("hello", info)
     assert "snippet text" in reply
     assert "excited" in calls['query']
+    assert "speech" in calls['query']
+    assert "excited" in reply
+    assert "speech" in reply


### PR DESCRIPTION
## Summary
- incorporate emotion and environment info in response templates
- document the new manager behavior
- update response manager to format audio context
- extend tests for classification support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*
- `pytest tests/test_response_manager.py::test_generate_reply_queries_corpus -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686daf606ce0832eb0b37aa9de3cf626