### PR TITLE
Add CUDA container spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ docker run -it spiral_os
 ```
 
 From there you can run any of the demo scripts such as `python run_song_demo.py`.
+
+## Codex GPU Deployment
+
+A container spec `spiral_os_container.yaml` is provided for running the tools with CUDA support. Build and launch it with:
+
+```bash
+codex run spiral_os_container.yaml
+```
+
+This installs the requirements and creates empty folders for the CORPUS MEMORY collections.

--- a/spiral_os_container.yaml
+++ b/spiral_os_container.yaml
@@ -1,0 +1,12 @@
+image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+packages:
+  - git
+  - ffmpeg
+  - build-essential
+  - libsndfile1
+copy:
+  - requirements.txt
+run:
+  - pip install --no-cache-dir -r requirements.txt
+  - mkdir -p INANNA_AI GENESIS IGNITION QNL_LANGUAGE
+cmd: ["bash"]


### PR DESCRIPTION
## Summary
- add `spiral_os_container.yaml` for CUDA 11.8 deployments
- document running the container in `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686db551c0d4832e8fd157ec2dc7a160