### PR TITLE
Add MoGEOrchestrator routing

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Multimodal Generative Expression orchestrator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from typing import Any, Dict
+import soundfile as sf
+
+from inanna_ai import response_manager, tts_coqui, emotion_analysis
+from SPIRAL_OS import qnl_engine
+
+
+class MoGEOrchestrator:
+    """Route text and emotion data to the available models."""
+
+    def __init__(self) -> None:
+        self._responder = response_manager.ResponseManager()
+
+    @staticmethod
+    def _select_plane(weight: float, archetype: str) -> str:
+        """Return ``ascension`` or ``underworld`` based on ``weight`` and ``archetype``."""
+        if weight >= 0.6 or archetype.lower() in {"hero", "sage", "jester"}:
+            return "ascension"
+        return "underworld"
+
+    def route(
+        self,
+        text: str,
+        emotion_data: Dict[str, Any],
+        *,
+        text_modality: bool = True,
+        voice_modality: bool = False,
+        music_modality: bool = False,
+    ) -> Dict[str, Any]:
+        """Process ``text`` with models based on ``emotion_data`` and flags."""
+        emotion = emotion_data.get("emotion", "neutral")
+        archetype = emotion_data.get("archetype") or emotion_analysis.emotion_to_archetype(emotion)
+        weight = emotion_data.get("weight")
+        if weight is None:
+            weight = emotion_analysis.emotion_weight(emotion)
+        plane = self._select_plane(weight, archetype)
+
+        result: Dict[str, Any] = {
+            "plane": plane,
+            "archetype": archetype,
+            "weight": weight,
+        }
+
+        if text_modality:
+            result["text"] = self._responder.generate_reply(text, emotion_data)
+
+        if voice_modality:
+            speech_input = result.get("text", text)
+            result["voice_path"] = tts_coqui.synthesize_speech(speech_input, emotion)
+
+        if music_modality:
+            hex_input = text.encode("utf-8").hex()
+            phrases, wave = qnl_engine.hex_to_song(hex_input, duration_per_byte=0.05)
+            wav_path = Path(tempfile.gettempdir()) / f"qnl_{abs(hash(hex_input))}.wav"
+            sf.write(wav_path, wave, 44100)
+            result["music_path"] = str(wav_path)
+            result["qnl_phrases"] = phrases
+
+        return result
+
+
+__all__ = ["MoGEOrchestrator"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from orchestrator import MoGEOrchestrator
+
+
+def test_route_text_only(tmp_path, monkeypatch):
+    orch = MoGEOrchestrator()
+    info = {"emotion": "joy"}
+    monkeypatch.setattr(
+        "inanna_ai.corpus_memory.search_corpus",
+        lambda *a, **k: [("p", "snippet")],
+    )
+    result = orch.route("hello", info, text_modality=True, voice_modality=False, music_modality=False)
+    assert result["plane"] == "ascension"
+    assert "text" in result and result["text"]
+
+
+def test_route_voice(tmp_path):
+    orch = MoGEOrchestrator()
+    info = {"emotion": "calm"}
+    result = orch.route("hi", info, text_modality=False, voice_modality=True, music_modality=False)
+    assert result["plane"] == "ascension"
+    assert Path(result["voice_path"]).exists()
+
+
+def test_route_music(tmp_path):
+    orch = MoGEOrchestrator()
+    info = {"emotion": "joy"}
+    result = orch.route("hi", info, text_modality=False, voice_modality=False, music_modality=True)
+    assert Path(result["music_path"]).exists()
+    assert result["qnl_phrases"]


### PR DESCRIPTION
## Summary
- implement `MoGEOrchestrator` for routing multimodal tasks
- write unit tests covering text, voice and music modes

## Testing
- `pytest tests/test_orchestrator.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tokenizers')*

------
https://chatgpt.com/codex/tasks/task_e_686db91baf08832e88871a9d9734cda5