### PR TITLE
Add gTTS speaking engine

### DIFF
--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "utils",
     "tts_coqui",
     "voice_evolution",
+    "speaking_engine",
     "db_storage",
     "listening_engine",
     "response_manager",

--- a/inanna_ai/speaking_engine.py
+++ b/inanna_ai/speaking_engine.py
@@ -1,0 +1,75 @@
+"""Generate speech using gTTS with emotion-based style adjustments."""
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+import librosa
+
+from .utils import save_wav
+from .voice_evolution import get_voice_params
+from .emotion_analysis import emotion_to_archetype
+
+try:
+    from gtts import gTTS
+except Exception:  # pragma: no cover - optional dependency
+    gTTS = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def _sine_placeholder(text: str) -> Tuple[np.ndarray, int]:
+    """Return a simple sine wave when gTTS is unavailable."""
+    duration = max(1.0, len(text) / 20)
+    sr = 22050
+    t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+    wave = 0.1 * np.sin(2 * np.pi * 220 * t)
+    return wave.astype(np.float32), sr
+
+
+def _apply_style(wave: np.ndarray, sr: int, style: Dict[str, float]) -> np.ndarray:
+    """Apply pitch shift and speed change according to ``style``."""
+    pitch = style.get("pitch", 0.0)
+    speed = style.get("speed", 1.0)
+    if pitch:
+        wave = librosa.effects.pitch_shift(wave, sr=sr, n_steps=pitch)
+    if speed and speed != 1.0:
+        wave = librosa.effects.time_stretch(wave, rate=speed)
+    return wave
+
+
+def synthesize_speech(text: str, emotion: str) -> str:
+    """Synthesize ``text`` to a WAV file styled by ``emotion``."""
+    style = get_voice_params(emotion)
+    archetype = emotion_to_archetype(emotion)
+    out_path = Path(tempfile.gettempdir()) / f"gtts_{abs(hash(text))}.wav"
+
+    if gTTS is None:
+        wave, sr = _sine_placeholder(f"{archetype} {text}")
+    else:
+        try:
+            mp3_a = out_path.with_suffix(".arch.mp3")
+            mp3_b = out_path.with_suffix(".text.mp3")
+            gTTS(text=archetype).save(str(mp3_a))
+            gTTS(text=text).save(str(mp3_b))
+            wave_a, sr = librosa.load(str(mp3_a), sr=None, mono=True)
+            wave_b, sr_b = librosa.load(str(mp3_b), sr=None, mono=True)
+            mp3_a.unlink(missing_ok=True)
+            mp3_b.unlink(missing_ok=True)
+            if sr_b != sr:
+                wave_b = librosa.resample(wave_b, sr_b, sr)
+            pause = np.zeros(int(sr * 0.2), dtype=np.float32)
+            wave = np.concatenate([wave_a, pause, wave_b])
+        except Exception as exc:  # pragma: no cover - external call may fail
+            logger.warning("gTTS synthesis failed: %s", exc)
+            wave, sr = _sine_placeholder(f"{archetype} {text}")
+
+    wave = _apply_style(wave, sr, style)
+    save_wav(wave, str(out_path), sr=sr)
+    return str(out_path)
+
+
+__all__ = ["synthesize_speech"]

--- a/tests/test_speaking_engine.py
+++ b/tests/test_speaking_engine.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import speaking_engine
+
+
+def test_synthesize_speech_creates_wav(tmp_path, monkeypatch):
+    class DummyTTS:
+        def __init__(self, text):
+            self.text = text
+        def save(self, path):
+            Path(path).write_bytes(b"dummy")
+    monkeypatch.setattr(speaking_engine, "gTTS", DummyTTS)
+    monkeypatch.setattr(speaking_engine, "emotion_to_archetype", lambda e: "Sage")
+    monkeypatch.setattr(speaking_engine, "get_voice_params", lambda e: {"speed": 1.0, "pitch": 0.0})
+    monkeypatch.setattr(speaking_engine.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(speaking_engine.librosa, "load", lambda *a, **k: (np.zeros(22050), 22050))
+
+    path = speaking_engine.synthesize_speech("hello", "calm")
+    assert Path(path).exists()


### PR DESCRIPTION
## Summary
- implement `speaking_engine.py` using gTTS with pitch and speed controls
- expose `speaking_engine` from package
- provide unit test for speech synthesis

## Testing
- `pip install numpy scipy pandas soundfile librosa tokenizers transformers torch sentencepiece accelerate einops` *(fails: ModuleNotFoundError: No module named 'librosa')*
- `pytest tests/test_speaking_engine.py -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_686dbfeb82dc832e953af17d1a019abc