### PR TITLE
Integrate orchestrator and speaking engine

### DIFF
--- a/inanna_ai/main.py
+++ b/inanna_ai/main.py
@@ -3,23 +3,14 @@ from __future__ import annotations
 """Command line interface for recording and responding with INANNA AI."""
 
 import argparse
-import logging
-
+from orchestrator import MoGEOrchestrator
 from . import (
     utils,
     stt_whisper,
-    emotion_analysis,
-    tts_coqui,
-    db_storage,
     listening_engine,
-    response_manager,
+    speaking_engine,
+    db_storage,
 )
-
-
-def generate_response(transcript: str, info: dict) -> str:
-    """Return a reply using :class:`ResponseManager`."""
-    mgr = response_manager.ResponseManager()
-    return mgr.generate_reply(transcript, info)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -31,21 +22,37 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--duration", type=float, default=3.0, help="Recording length in seconds")
     args = parser.parse_args(argv)
 
+    orchestrator = MoGEOrchestrator()
+    speaker = speaking_engine.SpeakingEngine()
     engine = listening_engine.ListeningEngine()
-    audio_path, emotion_info = engine.record(args.duration)
+
+    audio_path, audio_state = engine.record(args.duration)
     transcript = stt_whisper.transcribe_audio(audio_path)
-    if not emotion_info:
-        emotion_info = emotion_analysis.analyze_audio_emotion(audio_path)
-    emotion = emotion_info.get("emotion", "neutral")
 
-    response_text = generate_response(transcript, emotion_info)
-    response_path = tts_coqui.synthesize_speech(response_text, emotion)
+    result = orchestrator.route(
+        transcript,
+        audio_state,
+        text_modality=True,
+        voice_modality=True,
+        music_modality=False,
+    )
+    response_text = result.get("text", "")
+    voice_path = result.get("voice_path")
+    if voice_path:
+        speaker.play(voice_path)
+    else:
+        voice_path = speaker.speak(response_text, audio_state.get("emotion", "neutral"))
 
-    db_storage.save_interaction(transcript, emotion, response_path)
+    db_storage.save_interaction(
+        transcript,
+        audio_state.get("emotion", "neutral"),
+        voice_path,
+    )
 
     print(f"Transcript: {transcript}")
-    print(f"Emotion: {emotion}")
-    print(f"Response audio saved to: {response_path}")
+    print(f"Emotion: {audio_state.get('emotion', 'neutral')}")
+    print(f"Response: {response_text}")
+    print(f"Voice path: {voice_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/tests/test_speaking_engine.py
+++ b/tests/test_speaking_engine.py
@@ -22,3 +22,25 @@ def test_synthesize_speech_creates_wav(tmp_path, monkeypatch):
 
     path = speaking_engine.synthesize_speech("hello", "calm")
     assert Path(path).exists()
+
+
+def test_play_wav(monkeypatch):
+    played = {}
+
+    def dummy_load(path, sr=None, mono=True):
+        played["loaded"] = path
+        return np.zeros(10), 22050
+
+    class DummySD:
+        def play(self, wave, sr):
+            played["sr"] = sr
+        def wait(self):
+            played["waited"] = True
+
+    monkeypatch.setattr(speaking_engine, "sd", DummySD())
+    monkeypatch.setattr(speaking_engine, "load_audio", dummy_load)
+
+    speaking_engine.play_wav("x.wav")
+    assert played["loaded"] == "x.wav"
+    assert played["sr"] == 22050
+    assert played["waited"]


### PR DESCRIPTION
## Summary
- add playback and wrapper in speaking_engine
- update main to use MoGEOrchestrator and SpeakingEngine
- extend tests for speaking_engine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686dc2cfe60c832eb4681e3cb03e9b33