### PR TITLE
Add pipeline CLI and example config

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -92,3 +92,16 @@ INANNA_AI/
         ├── tokenizer.json
         └── ... (model files)
 ```
+
+## Pipeline Deployment
+
+The `spiral_os` CLI runs YAML workflows found in `SPIRAL_OS/pipelines/`.
+Deploy the bundled test pipeline with:
+
+```bash
+./spiral_os pipeline deploy SPIRAL_OS/pipelines/test_pipeline.yaml
+```
+
+Each step's `run` command executes sequentially. The example pipeline
+generates a short QNL song with 0.05‑second audio segments and mixes a
+three‑second preview track.

--- a/SPIRAL_OS/pipelines/test_pipeline.yaml
+++ b/SPIRAL_OS/pipelines/test_pipeline.yaml
@@ -1,0 +1,16 @@
+# Example pipeline for running the QNL engine and mixing audio
+# Each step is executed sequentially by `spiral_os pipeline deploy`
+
+steps:
+  - name: generate_qnl_song
+    run: |
+      python SPIRAL_OS/qnl_engine.py "48656c6c6f2053706972616c" \
+        --wav output/test_song.wav \
+        --json output/test_song.json \
+        --duration 0.05
+  - name: mix_preview
+    run: |
+      python SPIRAL_OS/mix_tracks.py output/test_song.wav \
+        --output output/final_mix.wav \
+        --preview output/preview.wav \
+        --preview-duration 3.0

--- a/SPIRAL_OS/qnl_engine.py
+++ b/SPIRAL_OS/qnl_engine.py
@@ -124,9 +124,15 @@ def main() -> None:
     parser.add_argument("hex_input", help="Hex string or path to text file containing hex bytes")
     parser.add_argument("--wav", default="qnl_hex_song.wav", help="Output WAV file")
     parser.add_argument("--json", default="qnl_hex_song.json", help="Output metadata JSON file")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=1.0,
+        help="Duration per hex byte in seconds",
+    )
     args = parser.parse_args()
 
-    phrases, waveform = hex_to_song(args.hex_input)
+    phrases, waveform = hex_to_song(args.hex_input, duration_per_byte=args.duration)
 
     write(args.wav, 44100, waveform)
     metadata = generate_qnl_metadata(phrases)

--- a/spiral_os
+++ b/spiral_os
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Simple CLI for running Spiral OS pipelines."""
+import argparse
+import subprocess
+from pathlib import Path
+import yaml
+
+
+def deploy_pipeline(path: str) -> None:
+    config = yaml.safe_load(Path(path).read_text())
+    for step in config.get("steps", []):
+        cmd = step["run"]
+        print(f"$ {cmd}")
+        subprocess.run(cmd, shell=True, check=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="spiral_os")
+    subparsers = parser.add_subparsers(dest="command")
+
+    pipeline = subparsers.add_parser("pipeline", help="Pipeline operations")
+    pipeline_sub = pipeline.add_subparsers(dest="action")
+
+    deploy = pipeline_sub.add_parser("deploy", help="Execute a pipeline YAML")
+    deploy.add_argument("pipeline", help="Path to YAML file")
+    deploy.set_defaults(func=lambda args: deploy_pipeline(args.pipeline))
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- add `spiral_os` CLI for running YAML pipelines
- support `--duration` option in `qnl_engine.py`
- include a test pipeline configuration
- document pipeline deployment in the operator guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_686dc55946c8832e9604665ceaddceef