### PR TITLE
Add orchestrator and speaking engine tests

### DIFF
--- a/tests/test_orchestrator_routing.py
+++ b/tests/test_orchestrator_routing.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from orchestrator import MoGEOrchestrator
+
+
+def test_route_all_modalities(monkeypatch, tmp_path):
+    orch = MoGEOrchestrator()
+    info = {"emotion": "joy"}
+
+    monkeypatch.setattr(
+        "inanna_ai.corpus_memory.search_corpus",
+        lambda *a, **k: [("p", "snippet")],
+    )
+
+    voice_path = tmp_path / "voice.wav"
+    monkeypatch.setattr(
+        "inanna_ai.tts_coqui.synthesize_speech",
+        lambda text, emotion: str(voice_path),
+    )
+
+    dummy_wave = np.zeros(10, dtype=np.int16)
+    monkeypatch.setattr(
+        "SPIRAL_OS.qnl_engine.hex_to_song",
+        lambda x, duration_per_byte=1.0: ([{"phrase": "p"}], dummy_wave),
+    )
+
+    written = {}
+
+    def fake_write(path, wave, sr):
+        written["path"] = path
+        written["wave"] = wave
+        written["sr"] = sr
+    monkeypatch.setattr("orchestrator.sf.write", fake_write)
+
+    result = orch.route(
+        "hello",
+        info,
+        text_modality=True,
+        voice_modality=True,
+        music_modality=True,
+    )
+
+    assert result["plane"] in {"ascension", "underworld"}
+    assert result["text"]
+    assert result["voice_path"] == str(voice_path)
+    assert result["music_path"] == str(written["path"])
+    assert result["qnl_phrases"] == [{"phrase": "p"}]
+    assert isinstance(written["wave"], np.ndarray)
+    assert written["sr"] == 44100

--- a/tests/test_speaking_behavior.py
+++ b/tests/test_speaking_behavior.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.speaking_engine import SpeakingEngine
+
+
+def test_speaking_engine_speak(monkeypatch):
+    engine = SpeakingEngine()
+    calls = []
+
+    monkeypatch.setattr(engine, "synthesize", lambda text, emotion: "file.wav")
+    monkeypatch.setattr(engine, "play", lambda path: calls.append(path))
+
+    path = engine.speak("hi", "calm")
+
+    assert path == "file.wav"
+    assert calls == ["file.wav"]
+


### PR DESCRIPTION
## Summary
- add test for orchestrator routing with all modalities mocked
- add test for SpeakingEngine.speak method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dca5a6688832e997884de60d21f7c