### PR TITLE
Add gate orchestrator to voice loop

### DIFF
--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "listening_engine",
     "response_manager",
     "rfa_7d",
+    "gate_orchestrator",
 ]

--- a/inanna_ai/gate_orchestrator.py
+++ b/inanna_ai/gate_orchestrator.py
@@ -1,0 +1,26 @@
+"""Simple gate orchestrator translating text to/from complex vectors."""
+from __future__ import annotations
+
+from typing import Sequence
+import numpy as np
+
+
+class GateOrchestrator:
+    """Map between text and complex vectors for the RFA7D core."""
+
+    def process_inward(self, text: str) -> Sequence[complex]:
+        """Convert ``text`` to a complex vector of length 128."""
+        data = text.encode("utf-8")[:128]
+        vec = [complex(b / 255.0, b / 255.0) for b in data]
+        if len(vec) < 128:
+            vec.extend([0j] * (128 - len(vec)))
+        return vec
+
+    def process_outward(self, grid: np.ndarray) -> str:
+        """Translate a grid back into a UTF-8 string."""
+        flat = np.asarray(grid).ravel()[:128]
+        values = [int(max(0, min(255, round(abs(float(z.real)) * 255)))) for z in flat]
+        return bytes(values).decode("utf-8", errors="ignore")
+
+
+__all__ = ["GateOrchestrator"]


### PR DESCRIPTION
## Summary
- implement GateOrchestrator for converting text to vectors and back
- integrate GateOrchestrator and RFA7D in `inanna_ai/main.py`
- update `__init__` exports
- add unit test verifying gate and core usage in voice loop

## Testing
- `pytest tests/test_speaking_behavior.py tests/test_inanna_ai.py::test_activate_returns_chant tests/test_inanna_ai.py::test_hex_cli_outputs_wav_and_json tests/test_inanna_ai.py::test_read_texts_empty_when_missing tests/test_inanna_ai.py::test_main_list_outputs_files tests/test_inanna_ai.py::test_chat_subparser tests/test_inanna_ai.py::test_voice_loop_gates -q`

------
https://chatgpt.com/codex/tasks/task_e_686df01b3564832e890089e10eb48f9c