### PR TITLE
Add signature integrity checks

### DIFF
--- a/inanna_ai/gates.py
+++ b/inanna_ai/gates.py
@@ -1,0 +1,29 @@
+"""Signature helpers for the RFA core."""
+from __future__ import annotations
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
+
+
+def sign_blob(blob: bytes, private_key_pem: bytes) -> bytes:
+    """Return a SHA256 signature for ``blob`` using the given private key."""
+    key = load_pem_private_key(private_key_pem, password=None)
+    return key.sign(blob, padding.PKCS1v15(), hashes.SHA256())
+
+
+def verify_blob(blob: bytes, signature: bytes, public_key_pem: bytes) -> bool:
+    """Validate ``signature`` for ``blob`` against ``public_key_pem``."""
+    key = load_pem_public_key(public_key_pem)
+    try:
+        key.verify(signature, blob, padding.PKCS1v15(), hashes.SHA256())
+        return True
+    except Exception:
+        return False
+
+
+__all__ = ["sign_blob", "verify_blob"]

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from OpenSSL import crypto
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.rfa_7d import RFA7D
+
+
+def _gen_keys():
+    pkey = crypto.PKey()
+    pkey.generate_key(crypto.TYPE_RSA, 2048)
+    priv = crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey)
+    pub = crypto.dump_publickey(crypto.FILETYPE_PEM, pkey)
+    return priv, pub
+
+
+def test_tampered_grid_fails_execution():
+    priv, pub = _gen_keys()
+    core = RFA7D()
+    core.sign_core(priv, pub)
+    core.grid = np.copy(core.grid)
+    core.grid.flat[0] += 1  # tamper with data
+    vec = [0j] * core.grid.size
+    with pytest.raises(RuntimeError):
+        core.execute(vec)
+
+
+def test_valid_grid_executes():
+    priv, pub = _gen_keys()
+    core = RFA7D()
+    core.sign_core(priv, pub)
+    vec = [1 + 0j] * core.grid.size
+    out = core.execute(vec)
+    assert out.shape == core.shape


### PR DESCRIPTION
## Summary
- add gates.py with helpers to sign and verify data using `cryptography`
- extend RFA7D with signing, verification and execution protection
- add tests that tamper with the grid and ensure execution halts

## Testing
- `pytest tests/test_integrity.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfa7796e0832e9f3da4183e720515