### PR TITLE
Add additional model downloads and quantization

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -81,6 +81,16 @@ these steps to place the model under `INANNA_AI/models`.
    The script loads `HF_TOKEN` from `secrets.env` in the project root and downloads
    `deepseek-ai/DeepSeek-R1` into `INANNA_AI/models/DeepSeek-R1/`.
    To fetch the Gemma2 model via Ollama run `python download_models.py gemma2`.
+   Additional models can be fetched the same way:
+
+   ```bash
+   python download_models.py glm41v_9b --int8       # GLM-4.1V-9B
+   python download_models.py deepseek_v3           # DeepSeek-V3
+   python download_models.py mistral_8x22b --int8  # Mistral 8x22B
+   ```
+
+   The `--int8` flag performs optional quantization with bitsandbytes for GPUs
+   like the A6000.
 
 Afterwards the directory structure should look like:
 

--- a/download_models.py
+++ b/download_models.py
@@ -5,6 +5,27 @@ import subprocess
 from pathlib import Path
 
 from download_model import download_deepseek  # reuse logic
+from dotenv import load_dotenv
+from huggingface_hub import snapshot_download
+
+
+def _get_hf_token() -> str:
+    """Load the Hugging Face token from the environment."""
+    load_dotenv()
+    token = os.getenv("HF_TOKEN")
+    if not token:
+        raise RuntimeError("HF_TOKEN environment variable not set")
+    return token
+
+
+def _quantize_to_int8(model_dir: Path) -> None:
+    """Quantize weights in place using bitsandbytes 8-bit loaders."""
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(
+        str(model_dir), device_map="auto", load_in_8bit=True
+    )
+    model.save_pretrained(str(model_dir))
 
 
 def download_gemma2() -> None:
@@ -25,20 +46,79 @@ def download_gemma2() -> None:
     print(f"Model downloaded to {models_dir / 'gemma2'}")
 
 
+def download_glm41v_9b(int8: bool = False) -> None:
+    """Download GLM-4.1V-9B from Hugging Face and optionally quantize."""
+    token = _get_hf_token()
+    target_dir = Path("INANNA_AI") / "models" / "GLM-4.1V-9B"
+    snapshot_download(
+        repo_id="THUDM/glm-4.1v-9b",
+        token=token,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+    )
+    if int8:
+        _quantize_to_int8(target_dir)
+    print(f"Model downloaded to {target_dir}")
+
+
+def download_deepseek_v3(int8: bool = False) -> None:
+    """Download DeepSeek-V3 from Hugging Face and optionally quantize."""
+    token = _get_hf_token()
+    target_dir = Path("INANNA_AI") / "models" / "DeepSeek-V3"
+    snapshot_download(
+        repo_id="deepseek-ai/DeepSeek-V3",
+        token=token,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+    )
+    if int8:
+        _quantize_to_int8(target_dir)
+    print(f"Model downloaded to {target_dir}")
+
+
+def download_mistral_8x22b(int8: bool = False) -> None:
+    """Download Mistral 8x22B from Hugging Face and optionally quantize."""
+    token = _get_hf_token()
+    target_dir = Path("INANNA_AI") / "models" / "Mistral-8x22B"
+    snapshot_download(
+        repo_id="mistralai/Mixtral-8x22B",
+        token=token,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+    )
+    if int8:
+        _quantize_to_int8(target_dir)
+    print(f"Model downloaded to {target_dir}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Model downloader")
     subparsers = parser.add_subparsers(dest="model", help="Model to download")
+
     subparsers.add_parser("deepseek", help="Download DeepSeek-R1 from Hugging Face")
     subparsers.add_parser("gemma2", help="Download Gemma2 via Ollama")
+    p = subparsers.add_parser("glm41v_9b", help="Download GLM-4.1V-9B")
+    p.add_argument("--int8", action="store_true", help="Quantize with bitsandbytes")
+    p = subparsers.add_parser("deepseek_v3", help="Download DeepSeek-V3")
+    p.add_argument("--int8", action="store_true", help="Quantize with bitsandbytes")
+    p = subparsers.add_parser("mistral_8x22b", help="Download Mistral 8x22B")
+    p.add_argument("--int8", action="store_true", help="Quantize with bitsandbytes")
 
     args = parser.parse_args()
     if args.model == "deepseek":
         download_deepseek()
     elif args.model == "gemma2":
         download_gemma2()
+    elif args.model == "glm41v_9b":
+        download_glm41v_9b(int8=args.int8)
+    elif args.model == "deepseek_v3":
+        download_deepseek_v3(int8=args.int8)
+    elif args.model == "mistral_8x22b":
+        download_mistral_8x22b(int8=args.int8)
     else:
         parser.print_help()
 
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_download_models.py
+++ b/tests/test_download_models.py
@@ -1,47 +1,65 @@
 import sys
 import importlib
+from types import ModuleType
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 
+def _prepare(monkeypatch):
+    dummy_hf = ModuleType("huggingface_hub")
+    dummy_hf.snapshot_download = lambda **kwargs: kwargs
+    monkeypatch.setitem(sys.modules, "huggingface_hub", dummy_hf)
+    dummy_dotenv = ModuleType("dotenv")
+    dummy_dotenv.load_dotenv = lambda: None
+    monkeypatch.setitem(sys.modules, "dotenv", dummy_dotenv)
+    dummy_tf = ModuleType("transformers")
+    class DummyModel:
+        called = {}
+        @classmethod
+        def from_pretrained(cls, path, device_map=None, load_in_8bit=False):
+            cls.called['args'] = (path, load_in_8bit)
+            return cls()
+        def save_pretrained(self, path):
+            DummyModel.called['save'] = path
+    dummy_tf.AutoModelForCausalLM = DummyModel
+    monkeypatch.setitem(sys.modules, "transformers", dummy_tf)
+
+
 def test_main_deepseek_calls_download(monkeypatch):
+    _prepare(monkeypatch)
     module = importlib.import_module("download_models")
 
     called = {}
+    monkeypatch.setattr(module, "download_deepseek", lambda: called.setdefault("deepseek", True))
 
-    def dummy():
-        called["deepseek"] = True
-
-    monkeypatch.setattr(module, "download_deepseek", dummy)
-    argv_backup = sys.argv.copy()
+    argv = sys.argv.copy()
     sys.argv = ["download_models.py", "deepseek"]
     try:
         module.main()
     finally:
-        sys.argv = argv_backup
+        sys.argv = argv
 
     assert called == {"deepseek": True}
 
 
 def test_main_gemma2_invokes_ollama(monkeypatch):
+    _prepare(monkeypatch)
     module = importlib.import_module("download_models")
 
     runs = []
-
     def dummy_run(cmd, *args, **kwargs):
         runs.append((cmd, kwargs))
-
     monkeypatch.setattr(module.subprocess, "run", dummy_run)
     monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/ollama")
 
-    argv_backup = sys.argv.copy()
+    argv = sys.argv.copy()
     sys.argv = ["download_models.py", "gemma2"]
     try:
         module.main()
     finally:
-        sys.argv = argv_backup
+        sys.argv = argv
 
     assert runs
     cmd, kwargs = runs[0]
@@ -49,3 +67,30 @@ def test_main_gemma2_invokes_ollama(monkeypatch):
     assert kwargs["check"] is True
     assert "env" in kwargs
     assert kwargs["env"]["OLLAMA_MODELS"].endswith("INANNA_AI/models")
+
+
+def test_glm41v_download_and_quant(monkeypatch):
+    _prepare(monkeypatch)
+    module = importlib.import_module("download_models")
+    monkeypatch.setenv("HF_TOKEN", "x")
+    module.download_glm41v_9b(int8=True)
+    called = sys.modules["transformers"].AutoModelForCausalLM.called
+    assert called["args"][1] is True
+    assert called["save"].endswith("GLM-4.1V-9B")
+
+
+def test_cli_mistral_invokes_function(monkeypatch):
+    _prepare(monkeypatch)
+    module = importlib.import_module("download_models")
+
+    called = {}
+    monkeypatch.setattr(module, "download_mistral_8x22b", lambda int8=False: called.setdefault("ok", int8))
+
+    argv = sys.argv.copy()
+    sys.argv = ["download_models.py", "mistral_8x22b", "--int8"]
+    try:
+        module.main()
+    finally:
+        sys.argv = argv
+
+    assert called == {"ok": True}


### PR DESCRIPTION
## Summary
- expand `download_models.py` with GLM-4.1V-9B, DeepSeek‑V3 and Mistral 8x22B
- support optional INT8 quantization via bitsandbytes
- update command‑line interface
- add unit tests for new functionality
- document new download commands in Operator guide

## Testing
- `pytest tests/test_download_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3a72cde0832eaf82619ad11d4068