### PR TITLE
Add network monitoring utilities

### DIFF
--- a/INANNA_AI_AGENT/network_utils_config.json
+++ b/INANNA_AI_AGENT/network_utils_config.json
@@ -1,0 +1,4 @@
+{
+  "log_dir": "../network_logs",
+  "capture_file": "../network_logs/capture.pcap"
+}

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -131,6 +131,24 @@ interfaces, verifies connectivity, and adjusts basic TCP parameters:
 ./spiral_os pipeline deploy SPIRAL_OS/pipelines/system_utilities_pipeline.yaml
 ```
 
+## Network monitoring
+
+The package `inanna_ai.network_utils` offers simple packet capture and
+analysis helpers. To record a short capture from interface `eth0`:
+
+```bash
+python -m inanna_ai.network_utils capture eth0 --count 50
+```
+
+The capture is written to `network_logs/capture.pcap`. Generate a traffic
+summary with:
+
+```bash
+python -m inanna_ai.network_utils analyze network_logs/capture.pcap
+```
+
+Results are saved to `network_logs/summary.log`.
+
 ## Soul-Code Architecture
 
 The spiritual core of INANNA is the **RFA7D** grid.  This seven‑dimensional

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -12,4 +12,5 @@ __all__ = [
     "rfa_7d",
     "gate_orchestrator",
     "train_soul",
+    "network_utils",
 ]

--- a/inanna_ai/network_utils/__init__.py
+++ b/inanna_ai/network_utils/__init__.py
@@ -1,0 +1,22 @@
+"""Network monitoring utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+CONFIG_FILE = Path(__file__).resolve().parents[2] / "INANNA_AI_AGENT" / "network_utils_config.json"
+
+_DEFAULT_CONFIG = {"log_dir": "network_logs", "capture_file": "network_logs/capture.pcap"}
+
+
+def load_config() -> dict:
+    """Return configuration for network utilities."""
+    if CONFIG_FILE.exists():
+        return json.loads(CONFIG_FILE.read_text())
+    return _DEFAULT_CONFIG.copy()
+
+
+from .capture import capture_packets
+from .analysis import analyze_capture
+
+__all__ = ["capture_packets", "analyze_capture", "load_config", "CONFIG_FILE"]

--- a/inanna_ai/network_utils/__main__.py
+++ b/inanna_ai/network_utils/__main__.py
@@ -1,0 +1,34 @@
+"""Command line entry for network utilities."""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .capture import capture_packets
+from .analysis import analyze_capture
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Network monitoring tools")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    cap = sub.add_parser("capture", help="Capture packets from an interface")
+    cap.add_argument("interface")
+    cap.add_argument("--count", type=int, default=20)
+    cap.add_argument("--output")
+
+    ana = sub.add_parser("analyze", help="Summarize a pcap file")
+    ana.add_argument("pcap")
+    ana.add_argument("--log-dir")
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    if args.cmd == "capture":
+        capture_packets(args.interface, count=args.count, output=args.output)
+    elif args.cmd == "analyze":
+        analyze_capture(args.pcap, log_dir=args.log_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/inanna_ai/network_utils/analysis.py
+++ b/inanna_ai/network_utils/analysis.py
@@ -1,0 +1,47 @@
+"""Basic traffic analysis for PCAP files."""
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+from . import load_config
+
+try:  # pragma: no cover - optional dependency
+    from scapy.all import rdpcap  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    rdpcap = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_capture(pcap_path: str, *, log_dir: Optional[str] = None) -> dict:
+    """Return a simple summary of the packets in ``pcap_path`` and save a log."""
+    if rdpcap is None:
+        raise RuntimeError("scapy is required for analysis")
+
+    packets = rdpcap(pcap_path)
+    proto_counts: Counter[str] = Counter()
+    talkers: Counter[str] = Counter()
+    for pkt in packets:
+        proto_counts[pkt.__class__.__name__] += 1
+        src = getattr(pkt, "src", None)
+        if src:
+            talkers[src] += 1
+
+    summary = {
+        "total_packets": len(packets),
+        "protocols": dict(proto_counts),
+        "top_talkers": talkers.most_common(5),
+    }
+
+    cfg = load_config()
+    log_directory = Path(log_dir or cfg.get("log_dir", "network_logs"))
+    log_directory.mkdir(parents=True, exist_ok=True)
+    log_file = log_directory / "summary.log"
+    log_file.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    logger.info("Saved summary to %s", log_file)
+    return summary

--- a/inanna_ai/network_utils/capture.py
+++ b/inanna_ai/network_utils/capture.py
@@ -1,0 +1,31 @@
+"""Packet capture helpers using scapy or pyshark."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from . import load_config
+
+try:  # pragma: no cover - optional dependency
+    from scapy.all import sniff, wrpcap  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    sniff = None
+    wrpcap = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def capture_packets(interface: str, *, count: int = 20, output: Optional[str] = None) -> None:
+    """Capture ``count`` packets from ``interface`` and write them to ``output``."""
+    cfg = load_config()
+    out_path = Path(output or cfg.get("capture_file", "capture.pcap"))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if sniff is None or wrpcap is None:
+        raise RuntimeError("scapy is required for packet capture")
+
+    packets = sniff(iface=interface, count=count)
+    wrpcap(str(out_path), packets)
+    logger.info("Captured %d packets to %s", len(packets), out_path)


### PR DESCRIPTION
## Summary
- add `inanna_ai.network_utils` with capture and analysis helpers
- allow packet capture via `python -m inanna_ai.network_utils`
- document usage in `README_OPERATOR.md`
- provide default config `network_utils_config.json`
- expose the package via `inanna_ai.__all__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e3ce52164832e87577fd76d2ec66a