### PR TITLE
Add network utils tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,3 +7,4 @@ markdown
 sentence-transformers
 transformers>=4.38
 torch>=2.1
+pyopenssl

--- a/tests/test_ethical_validator.py
+++ b/tests/test_ethical_validator.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Provide a stub if module is missing
+if "inanna_ai.ethical_validator" not in sys.modules:
+    mod = types.ModuleType("inanna_ai.ethical_validator")
+
+    class EthicalValidator:
+        def __init__(self, allowed_users=None):
+            self.allowed = set(allowed_users or [])
+
+        def validate(self, user, prompt):
+            if user not in self.allowed:
+                raise PermissionError("unauthorized")
+            return True
+
+    mod.EthicalValidator = EthicalValidator
+    sys.modules["inanna_ai.ethical_validator"] = mod
+
+from inanna_ai.ethical_validator import EthicalValidator
+
+
+def test_unauthorized_usage_rejected():
+    validator = EthicalValidator(allowed_users={"alice"})
+    with pytest.raises(PermissionError):
+        validator.validate("bob", "test")
+
+    assert validator.validate("alice", "ok") is True

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -1,0 +1,72 @@
+import sys
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.network_utils import capture_packets
+from inanna_ai.network_utils import analyze_capture
+
+
+def _dummy_packet(proto: str, src: str | None = None):
+    cls = type(proto, (), {})
+    pkt = cls()
+    if src:
+        setattr(pkt, "src", src)
+    return pkt
+
+
+def test_capture_packets(tmp_path, monkeypatch):
+    calls = {}
+
+    def sniff(iface=None, count=0):
+        calls["iface"] = iface
+        calls["count"] = count
+        return ["pkt"] * count
+
+    def wrpcap(path, packets):
+        calls["path"] = path
+        calls["packets"] = packets
+        Path(path).write_text("data")
+
+    monkeypatch.setattr("inanna_ai.network_utils.capture.sniff", sniff)
+    monkeypatch.setattr("inanna_ai.network_utils.capture.wrpcap", wrpcap)
+
+    out = tmp_path / "cap.pcap"
+    capture_packets("eth0", count=3, output=str(out))
+
+    assert out.exists()
+    assert calls == {
+        "iface": "eth0",
+        "count": 3,
+        "path": str(out),
+        "packets": ["pkt", "pkt", "pkt"],
+    }
+
+
+def test_analyze_capture(tmp_path, monkeypatch):
+    packets = [
+        _dummy_packet("TCP", "1.1.1.1"),
+        _dummy_packet("UDP", "2.2.2.2"),
+        _dummy_packet("TCP", "1.1.1.1"),
+    ]
+
+    def rdpcap(path):
+        assert path == "dummy.pcap"
+        return packets
+
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr("inanna_ai.network_utils.analysis.rdpcap", rdpcap)
+    monkeypatch.setattr(
+        "inanna_ai.network_utils.analysis.load_config", lambda: {"log_dir": str(log_dir)}
+    )
+
+    summary = analyze_capture("dummy.pcap")
+    assert summary["total_packets"] == 3
+    assert summary["protocols"] == {"TCP": 2, "UDP": 1}
+    assert summary["top_talkers"][0][0] == "1.1.1.1"
+
+    log_file = log_dir / "summary.log"
+    assert log_file.exists()
+    assert json.loads(log_file.read_text()) == summary


### PR DESCRIPTION
## Summary
- add tests for network utilities
- add placeholder EthicalValidator tests
- include pyopenssl in test requirements

## Testing
- `pip install -q -r tests/requirements.txt`
- `pytest -q` *(fails: librosa ParameterError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_686e3fb93b68832eb7830963fa4a6e3a