### PR TITLE
Refactor pipeline execution

### DIFF
--- a/spiral_os
+++ b/spiral_os
@@ -3,15 +3,25 @@
 import argparse
 import subprocess
 from pathlib import Path
+import shlex
 import yaml
 
 
 def deploy_pipeline(path: str) -> None:
     config = yaml.safe_load(Path(path).read_text())
     for step in config.get("steps", []):
-        cmd = step["run"]
-        print(f"$ {cmd}")
-        subprocess.run(cmd, shell=True, check=True)
+        script = step["run"]
+        print(f"$ {script}")
+
+        # Collapse line continuations marked with a trailing backslash
+        normalized = script.replace("\\\n", " ")
+
+        for line in normalized.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            cmd = shlex.split(line)
+            subprocess.run(cmd, check=True)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_spiral_os.py
+++ b/tests/test_spiral_os.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+import builtins
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+
+spiral_os_path = ROOT / "spiral_os"
+loader = SourceFileLoader("spiral_os", str(spiral_os_path))
+spec = importlib.util.spec_from_loader("spiral_os", loader)
+spiral_os = importlib.util.module_from_spec(spec)
+loader.exec_module(spiral_os)
+
+
+def test_deploy_pipeline_runs_commands(monkeypatch, tmp_path):
+    # create simple pipeline YAML
+    yaml_text = """
+steps:
+  - name: greet
+    run: echo hello
+"""
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text(yaml_text)
+
+    calls = []
+
+    def fake_run(args, check):
+        calls.append(args)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(spiral_os.subprocess, "run", fake_run)
+
+    spiral_os.deploy_pipeline(str(pipeline))
+
+    assert calls == [["echo", "hello"]]
+
+
+def test_deploy_pipeline_multiline(monkeypatch, tmp_path):
+    yaml_text = """
+steps:
+  - name: multi
+    run: |
+      echo hello \
+        world
+"""
+    pipeline = tmp_path / "p.yaml"
+    pipeline.write_text(yaml_text)
+
+    calls = []
+
+    def fake_run(args, check):
+        calls.append(args)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(spiral_os.subprocess, "run", fake_run)
+
+    spiral_os.deploy_pipeline(str(pipeline))
+
+    assert calls == [["echo", "hello", "world"]]


### PR DESCRIPTION
## Summary
- avoid using `shell=True` when running pipeline commands
- normalize escaped newlines and execute each line as a list via `subprocess.run`
- add regression tests for simple and multi-line pipeline commands

## Testing
- `pytest tests/test_spiral_os.py -q`
- `pytest -q` *(fails: ParameterError, AttributeError, ZeroDivisionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e428dcf6c832eaa08b35295cf38de