### PR TITLE
Bundle network utils config

### DIFF
--- a/inanna_ai/network_utils/__init__.py
+++ b/inanna_ai/network_utils/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+from importlib import resources
 
 CONFIG_FILE = Path(__file__).resolve().parents[2] / "INANNA_AI_AGENT" / "network_utils_config.json"
 
@@ -13,6 +14,14 @@ def load_config() -> dict:
     """Return configuration for network utilities."""
     if CONFIG_FILE.exists():
         return json.loads(CONFIG_FILE.read_text())
+
+    try:
+        resource_path = resources.files("inanna_ai") / "network_utils_config.json"
+        if resource_path.is_file():
+            return json.loads(resource_path.read_text())
+    except Exception:
+        pass
+
     return _DEFAULT_CONFIG.copy()
 
 

--- a/inanna_ai/network_utils/analysis.py
+++ b/inanna_ai/network_utils/analysis.py
@@ -32,10 +32,11 @@ def analyze_capture(pcap_path: str, *, log_dir: Optional[str] = None) -> dict:
         if src:
             talkers[src] += 1
 
+    top_talkers = [[addr, count] for addr, count in talkers.most_common(5)]
     summary = {
         "total_packets": len(packets),
         "protocols": dict(proto_counts),
-        "top_talkers": talkers.most_common(5),
+        "top_talkers": top_talkers,
     }
 
     cfg = load_config()

--- a/inanna_ai/network_utils_config.json
+++ b/inanna_ai/network_utils_config.json
@@ -1,0 +1,4 @@
+{
+  "log_dir": "network_logs",
+  "capture_file": "network_logs/capture.pcap"
+}


### PR DESCRIPTION
## Summary
- bundle network utilities config in the `inanna_ai` package
- load the resource using `importlib.resources` with fallback to `_DEFAULT_CONFIG`
- make `analyze_capture` return JSON-friendly talker lists
- test the new `load_config` behaviour

## Testing
- `pytest tests/test_network_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e52aaf2a0832eb111cb8a788222ee