### PR TITLE
Add Vast.ai deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ For details on the RFA7D core and the seven gate interface, see
 [docs/SOUL_CODE.md](docs/SOUL_CODE.md).
 For an overview of available agents and defensive modules, see
 [AGENTS.md](AGENTS.md#upcoming-components).
+For notes on deploying to Vast.ai, see
+[docs/VAST_DEPLOYMENT.md](docs/VAST_DEPLOYMENT.md).
 
 ## Docker Usage
 

--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -1,0 +1,41 @@
+# Vast.ai Deployment
+
+This guide explains how to run the SPIRAL_OS tools on a Vast.ai server.
+
+## Select a PyTorch template
+
+1. Log in to [Vast.ai](https://vast.ai) and create a new rental.
+2. Choose a GPU offer that lists the **PyTorch** template. This image ships with CUDA and Python preinstalled.
+3. Launch the instance and connect via SSH once it is ready.
+
+## Clone the repository and install requirements
+
+After connecting to the server run:
+
+```bash
+# clone the project
+git clone https://github.com/your-user/SPIRAL_OS.git
+cd SPIRAL_OS
+
+# install Python packages
+pip install -r requirements.txt
+```
+
+Optionally install the test requirements with:
+
+```bash
+pip install -r tests/requirements.txt
+```
+
+## GPU setup and model downloads (optional)
+
+If your instance provides a GPU you can pull model weights. The helper script
+below creates directories and fetches models for you:
+
+```bash
+bash scripts/setup_vast_ai.sh
+```
+
+The script installs dependencies, prepares the `INANNA_AI/models` folder and can
+invoke `download_models.py` to pull large checkpoints. Edit the script to suit
+your needs.

--- a/scripts/setup_vast_ai.sh
+++ b/scripts/setup_vast_ai.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Basic setup script for Vast.ai instances
+set -e
+
+# install dependencies
+pip install -r requirements.txt
+
+# create directories for models and outputs
+mkdir -p INANNA_AI/models
+mkdir -p output
+
+# placeholder model download (optional)
+if [ "$1" = "--download" ]; then
+    python download_models.py deepseek || true
+fi


### PR DESCRIPTION
## Summary
- document Vast.ai setup
- provide simple setup script
- link new doc from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e56791950832e9d703077d0f38503