### PR TITLE
Add banned keyword validation to EthicalValidator

### DIFF
--- a/inanna_ai/ethical_validator.py
+++ b/inanna_ai/ethical_validator.py
@@ -6,16 +6,44 @@ unauthorized sources before they reach the language models.
 from __future__ import annotations
 
 from typing import Iterable
+from pathlib import Path
+from datetime import datetime
 
 
 class EthicalValidator:
-    """Rejects prompts from unauthorized users."""
+    """Rejects prompts from unauthorized users and banned text."""
 
-    def __init__(self, allowed_users: Iterable[str] | None = None) -> None:
+    def __init__(
+        self,
+        allowed_users: Iterable[str] | None = None,
+        *,
+        banned_keywords: Iterable[str] | None = None,
+        log_dir: str | Path = "audit_logs",
+    ) -> None:
         self.allowed = set(allowed_users or [])
+        self.banned = [kw.lower() for kw in (banned_keywords or [])]
+        self.log_dir = Path(log_dir)
+
+    def _log_rejected(self, text: str) -> None:
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = self.log_dir / "rejected_prompts.log"
+        timestamp = datetime.utcnow().isoformat()
+        with log_file.open("a", encoding="utf-8") as fh:
+            fh.write(f"{timestamp} {text}\n")
+
+    def validate_text(self, text: str) -> bool:
+        """Return ``True`` if ``text`` contains no banned keywords."""
+        lowered = text.lower()
+        for kw in self.banned:
+            if kw in lowered:
+                self._log_rejected(text)
+                return False
+        return True
 
     def validate(self, user: str, prompt: str) -> bool:
-        """Return ``True`` if ``user`` is authorized or raise ``PermissionError``."""
+        """Validate ``prompt`` and ``user``. Raises on failure."""
+        if not self.validate_text(prompt):
+            raise ValueError("banned content")
         if user not in self.allowed:
             raise PermissionError("unauthorized")
         return True


### PR DESCRIPTION
## Summary
- expand EthicalValidator with text validation and prompt logging
- log rejected prompts to configurable directory
- extend tests for banned keyword handling

## Testing
- `pytest tests/test_ethical_validator.py -q`
- `pytest -k ethical_validator -q` *(fails: ModuleNotFoundError: No module named 'librosa', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d036eb0832eabd12fe79f502272