### PR TITLE
Add defensive network utilities

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -149,6 +149,20 @@ python -m inanna_ai.network_utils analyze network_logs/capture.pcap
 
 Results are saved to `network_logs/summary.log`.
 
+### Defensive helpers
+
+The module `inanna_ai.defensive_network_utils` offers two quick utilities:
+
+```python
+from inanna_ai.defensive_network_utils import monitor_traffic, secure_communication
+
+monitor_traffic("eth0", packet_count=5)  # writes network_logs/defensive.pcap
+secure_communication("https://example.com/api", {"status": "ok"})
+```
+
+`monitor_traffic()` captures a handful of packets while
+`secure_communication()` sends an HTTPS POST request with basic error handling.
+
 
 ## Soul-Code Architecture
 

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -13,5 +13,6 @@ __all__ = [
     "gate_orchestrator",
     "train_soul",
     "network_utils",
+    "defensive_network_utils",
     "ethical_validator",
 ]

--- a/inanna_ai/defensive_network_utils.py
+++ b/inanna_ai/defensive_network_utils.py
@@ -1,0 +1,51 @@
+"""Defensive network helpers for monitoring and secure POST requests."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from scapy.all import sniff, wrpcap  # type: ignore
+except Exception:  # pragma: no cover - fallback when scapy missing
+    sniff = None
+    wrpcap = None
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - fallback when requests missing
+    requests = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def monitor_traffic(interface: str, packet_count: int = 5) -> None:
+    """Capture packets from ``interface`` and store them in ``network_logs/defensive.pcap``."""
+    if sniff is None or wrpcap is None:
+        raise RuntimeError("scapy is required for packet capture")
+
+    log_dir = Path("network_logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    pcap_path = log_dir / "defensive.pcap"
+
+    packets = sniff(iface=interface, count=packet_count)
+    wrpcap(str(pcap_path), packets)
+    logger.info("Captured %d packets to %s", len(packets), pcap_path)
+
+
+def secure_communication(url: str, data: dict[str, Any]):
+    """Send ``data`` via HTTPS POST to ``url`` with basic error handling.
+
+    Returns the :class:`requests.Response` object on success.
+    """
+    if requests is None:
+        raise RuntimeError("requests library is required for secure communication")
+
+    try:
+        response = requests.post(url, json=data, timeout=10)
+        response.raise_for_status()
+        return response
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("Failed to post to %s: %s", url, exc)
+        raise

--- a/tests/test_defensive_network_utils.py
+++ b/tests/test_defensive_network_utils.py
@@ -1,0 +1,85 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import defensive_network_utils as dnu
+from inanna_ai.defensive_network_utils import monitor_traffic, secure_communication
+
+
+def test_monitor_traffic(tmp_path, monkeypatch):
+    calls = {}
+
+    def sniff(iface=None, count=0):
+        calls['iface'] = iface
+        calls['count'] = count
+        return ['pkt'] * count
+
+    def wrpcap(path, packets):
+        calls['path'] = path
+        calls['packets'] = packets
+        Path(path).write_text('data')
+
+    monkeypatch.setattr('inanna_ai.defensive_network_utils.sniff', sniff)
+    monkeypatch.setattr('inanna_ai.defensive_network_utils.wrpcap', wrpcap)
+    monkeypatch.chdir(tmp_path)
+
+    monitor_traffic('eth0', packet_count=3)
+
+    pcap = tmp_path / 'network_logs' / 'defensive.pcap'
+    assert pcap.exists()
+    assert calls == {
+        'iface': 'eth0',
+        'count': 3,
+        'path': 'network_logs/defensive.pcap',
+        'packets': ['pkt', 'pkt', 'pkt'],
+    }
+
+
+def test_secure_communication(monkeypatch):
+    resp = SimpleNamespace(status_code=200, text='ok')
+    resp.raise_for_status = lambda: None
+    calls = {}
+
+    dummy = ModuleType('requests')
+    dummy.RequestException = Exception
+
+    def post(url, json=None, timeout=None):
+        calls['url'] = url
+        calls['json'] = json
+        calls['timeout'] = timeout
+        return resp
+
+    dummy.post = post
+    monkeypatch.setitem(sys.modules, 'requests', dummy)
+    monkeypatch.setattr(dnu, 'requests', dummy)
+
+    out = secure_communication('https://example.com', {'a': 1})
+    assert out is resp
+    assert calls == {
+        'url': 'https://example.com',
+        'json': {'a': 1},
+        'timeout': 10,
+    }
+
+
+def test_secure_communication_error(monkeypatch):
+    class DummyExc(Exception):
+        pass
+
+    dummy = ModuleType('requests')
+    dummy.RequestException = DummyExc
+
+    def post(url, json=None, timeout=None):
+        raise DummyExc('fail')
+
+    dummy.post = post
+    monkeypatch.setitem(sys.modules, 'requests', dummy)
+    monkeypatch.setattr(dnu, 'requests', dummy)
+
+    with pytest.raises(DummyExc):
+        secure_communication('https://bad.com', {'x': 1})
+


### PR DESCRIPTION
## Summary
- implement `defensive_network_utils.py` with packet capture and HTTPS POST helpers
- expose new module in `inanna_ai.__init__`
- document defensive helpers in README_OPERATOR.md
- add unit tests for monitoring and communication functions

## Testing
- `pytest -q tests/test_defensive_network_utils.py`
- `pytest -q tests/test_network_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6ef6b518832ebaa0b0308d231033