### PR TITLE
Add GLM audit utilities

### DIFF
--- a/INANNA_AI/glm_analyze.py
+++ b/INANNA_AI/glm_analyze.py
@@ -1,0 +1,48 @@
+"""Analyze Python modules using a placeholder GLM endpoint."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - fallback when requests missing
+    requests = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parents[1]
+CODE_DIR = ROOT / "inanna_ai"
+AUDIT_DIR = ROOT / "audit_logs"
+ANALYSIS_FILE = AUDIT_DIR / "code_analysis.txt"
+ENDPOINT = "https://api.example.com/glm"
+
+
+def analyze_code() -> str:
+    """Send code base to the GLM endpoint and store the suggestions."""
+    if requests is None:
+        raise RuntimeError("requests library is required")
+
+    snippets = []
+    if CODE_DIR.exists():
+        for path in CODE_DIR.rglob("*.py"):
+            try:
+                snippets.append(f"# {path}\n{path.read_text(encoding='utf-8')}")
+            except Exception:  # pragma: no cover - unreadable file
+                logger.warning("Failed to read %s", path)
+
+    data = {"text": "\n".join(snippets)}
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    resp = requests.post(ENDPOINT, json=data, timeout=10)
+    try:
+        analysis = resp.json().get("analysis", "")
+    except Exception:  # pragma: no cover - non-json response
+        analysis = resp.text
+
+    ANALYSIS_FILE.write_text(analysis, encoding="utf-8")
+    logger.info("Wrote code analysis to %s", ANALYSIS_FILE)
+    return analysis
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    print(analyze_code())

--- a/INANNA_AI/glm_init.py
+++ b/INANNA_AI/glm_init.py
@@ -1,0 +1,51 @@
+"""Summarize project purpose using a placeholder GLM endpoint."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - fallback when requests missing
+    requests = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parents[1]
+README_FILE = ROOT / "README.md"
+QNL_DIR = ROOT / "QNL_LANGUAGE"
+AUDIT_DIR = ROOT / "audit_logs"
+PURPOSE_FILE = AUDIT_DIR / "purpose.txt"
+ENDPOINT = "https://api.example.com/glm"
+
+
+def summarize_purpose() -> str:
+    """Read project texts and store a summary produced by the GLM endpoint."""
+    if requests is None:
+        raise RuntimeError("requests library is required")
+
+    texts = []
+    if README_FILE.exists():
+        texts.append(README_FILE.read_text(encoding="utf-8"))
+    if QNL_DIR.exists():
+        for path in QNL_DIR.glob("*.md"):
+            try:
+                texts.append(path.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - unreadable file
+                logger.warning("Failed to read %s", path)
+
+    data = {"text": "\n".join(texts)}
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    resp = requests.post(ENDPOINT, json=data, timeout=10)
+    try:
+        summary = resp.json().get("summary", "")
+    except Exception:  # pragma: no cover - non-json response
+        summary = resp.text
+
+    PURPOSE_FILE.write_text(summary, encoding="utf-8")
+    logger.info("Wrote summary to %s", PURPOSE_FILE)
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    print(summarize_purpose())

--- a/tests/test_glm_modules.py
+++ b/tests/test_glm_modules.py
@@ -1,0 +1,62 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from INANNA_AI import glm_init, glm_analyze
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, str]):
+        self._data = data
+        self.text = data.get('summary') or data.get('analysis', '')
+
+    def json(self):
+        return self._data
+
+
+def test_glm_init_summarize(tmp_path, monkeypatch):
+    readme = tmp_path / 'README.md'
+    qnl = tmp_path / 'QNL_LANGUAGE'
+    qnl.mkdir()
+    readme.write_text('hello', encoding='utf-8')
+    (qnl / 'a.md').write_text('world', encoding='utf-8')
+
+    out_dir = tmp_path / 'audit_logs'
+
+    monkeypatch.setattr(glm_init, 'ROOT', tmp_path)
+    monkeypatch.setattr(glm_init, 'README_FILE', readme)
+    monkeypatch.setattr(glm_init, 'QNL_DIR', qnl)
+    monkeypatch.setattr(glm_init, 'AUDIT_DIR', out_dir)
+    monkeypatch.setattr(glm_init, 'PURPOSE_FILE', out_dir / 'purpose.txt')
+
+    dummy = ModuleType('requests')
+    dummy.post = lambda *a, **k: DummyResponse({'summary': 'sum'})
+    monkeypatch.setattr(glm_init, 'requests', dummy)
+
+    summary = glm_init.summarize_purpose()
+    assert summary == 'sum'
+    assert (out_dir / 'purpose.txt').read_text() == 'sum'
+
+
+def test_glm_analyze_code(tmp_path, monkeypatch):
+    code_dir = tmp_path / 'inanna_ai'
+    code_dir.mkdir()
+    (code_dir / 'x.py').write_text('print(1)', encoding='utf-8')
+
+    out_dir = tmp_path / 'audit_logs'
+
+    monkeypatch.setattr(glm_analyze, 'ROOT', tmp_path)
+    monkeypatch.setattr(glm_analyze, 'CODE_DIR', code_dir)
+    monkeypatch.setattr(glm_analyze, 'AUDIT_DIR', out_dir)
+    monkeypatch.setattr(glm_analyze, 'ANALYSIS_FILE', out_dir / 'code_analysis.txt')
+
+    dummy = ModuleType('requests')
+    dummy.post = lambda *a, **k: DummyResponse({'analysis': 'ok'})
+    monkeypatch.setattr(glm_analyze, 'requests', dummy)
+
+    analysis = glm_analyze.analyze_code()
+    assert analysis == 'ok'
+    assert (out_dir / 'code_analysis.txt').read_text() == 'ok'


### PR DESCRIPTION
## Summary
- add `glm_init.py` for summarizing repo purpose
- add `glm_analyze.py` for code inefficiency analysis
- implement unit tests covering both modules

## Testing
- `pytest tests/test_glm_modules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e70bd28f0832e8eb1a5a53f8bd301