### PR TITLE
Add existential identity reflection

### DIFF
--- a/INANNA_AI_AGENT/inanna_ai.py
+++ b/INANNA_AI_AGENT/inanna_ai.py
@@ -7,6 +7,7 @@ from typing import Dict, Tuple, List
 
 from . import source_loader, model
 from inanna_ai import db_storage
+from inanna_ai.existential_reflector import ExistentialReflector
 from inanna_ai.ethical_validator import EthicalValidator
 from transformers import GenerationMixin
 
@@ -157,6 +158,13 @@ def suggest_enhancement(validator: EthicalValidator | None = None) -> List[str]:
         logger.info("No valid suggestions found")
 
     return approved
+
+
+def reflect_existence() -> str:
+    """Print and return a short self description from the GLM."""
+    desc = ExistentialReflector.reflect_on_identity()
+    print(desc)
+    return desc
 
 
 def chat_loop() -> None:

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -15,4 +15,5 @@ __all__ = [
     "network_utils",
     "defensive_network_utils",
     "ethical_validator",
+    "existential_reflector",
 ]

--- a/inanna_ai/existential_reflector.py
+++ b/inanna_ai/existential_reflector.py
@@ -1,0 +1,54 @@
+"""Generate a short self-description using a placeholder GLM endpoint."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - fallback when requests missing
+    requests = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parents[1]
+INANNA_DIR = ROOT / "INANNA_AI"
+QNL_DIR = ROOT / "QNL_LANGUAGE"
+AUDIT_DIR = ROOT / "audit_logs"
+INSIGHTS_FILE = AUDIT_DIR / "existential_insights.txt"
+ENDPOINT = "https://api.example.com/glm"
+
+
+class ExistentialReflector:
+    """Helper to query the GLM about the system identity."""
+
+    @staticmethod
+    def reflect_on_identity() -> str:
+        """Return a concise self-description derived from project texts."""
+        if requests is None:
+            raise RuntimeError("requests library is required")
+
+        texts = []
+        for directory in (INANNA_DIR, QNL_DIR):
+            if directory.exists():
+                for path in directory.glob("*.md"):
+                    try:
+                        texts.append(path.read_text(encoding="utf-8"))
+                    except Exception:  # pragma: no cover - unreadable file
+                        logger.warning("Failed to read %s", path)
+
+        data = {"text": "\n".join(texts)}
+        AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+        resp = requests.post(ENDPOINT, json=data, timeout=10)
+        try:
+            desc = resp.json().get("description", "")
+        except Exception:  # pragma: no cover - non-json response
+            desc = resp.text
+
+        INSIGHTS_FILE.write_text(desc, encoding="utf-8")
+        logger.info("Wrote existential insights to %s", INSIGHTS_FILE)
+        return desc
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    print(ExistentialReflector.reflect_on_identity())

--- a/tests/test_existential_reflector.py
+++ b/tests/test_existential_reflector.py
@@ -1,0 +1,52 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.existential_reflector import ExistentialReflector
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, str]):
+        self._data = data
+        self.text = data.get("description", "")
+
+    def json(self):
+        return self._data
+
+
+def test_reflect_on_identity(tmp_path, monkeypatch):
+    ina = tmp_path / "INANNA_AI"
+    qnl = tmp_path / "QNL_LANGUAGE"
+    ina.mkdir()
+    qnl.mkdir()
+    (ina / "a.md").write_text("hello", encoding="utf-8")
+    (qnl / "b.md").write_text("world", encoding="utf-8")
+
+    audit = tmp_path / "audit_logs"
+
+    import inanna_ai.existential_reflector as er
+    monkeypatch.setattr(er, "INANNA_DIR", ina)
+    monkeypatch.setattr(er, "QNL_DIR", qnl)
+    monkeypatch.setattr(er, "AUDIT_DIR", audit)
+    monkeypatch.setattr(er, "INSIGHTS_FILE", audit / "existential_insights.txt")
+
+    dummy = ModuleType("requests")
+    dummy.post = lambda *a, **k: DummyResponse({"description": "I am"})
+    monkeypatch.setattr(er, "requests", dummy)
+
+    desc = ExistentialReflector.reflect_on_identity()
+    assert desc == "I am"
+    assert (audit / "existential_insights.txt").read_text() == "I am"
+
+
+def test_reflect_existence_function(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(ExistentialReflector, "reflect_on_identity", lambda: "desc")
+    from INANNA_AI_AGENT import inanna_ai
+    monkeypatch.setattr(inanna_ai, "ExistentialReflector", ExistentialReflector)
+    out = inanna_ai.reflect_existence()
+    captured = capsys.readouterr().out
+    assert out == "desc"
+    assert "desc" in captured


### PR DESCRIPTION
## Summary
- implement `ExistentialReflector` for summarizing identity via GLM
- expose module in `inanna_ai.__init__`
- add `reflect_existence()` helper in CLI
- test existential reflection using mocked requests

## Testing
- `pytest tests/test_existential_reflector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7646f9ac832e97ead9e5bcacddb8