### PR TITLE
Add glm setup and repo cloning scripts

### DIFF
--- a/docs/VAST_DEPLOYMENT.md
+++ b/docs/VAST_DEPLOYMENT.md
@@ -39,3 +39,23 @@ bash scripts/setup_vast_ai.sh
 The script installs dependencies, prepares the `INANNA_AI/models` folder and can
 invoke `download_models.py` to pull large checkpoints. Edit the script to suit
 your needs.
+
+## Initialize GLM environment
+
+Run the setup script to install Python packages and create core directories under `/`:
+
+```bash
+bash scripts/setup_glm.sh
+```
+
+It prepares `/INANNA_AI`, `/QNL_LANGUAGE` and `/audit_logs` with placeholder ethics notes.
+
+## Clone a private repository
+
+If you need to pull another repository into the system use `setup_repo.sh` and a GitHub token:
+
+```bash
+GITHUB_TOKEN=your-token bash scripts/setup_repo.sh owner/repo
+```
+
+The script clones the repository to `/INANNA_AI/repo` and writes `confirmation.txt` once completed.

--- a/scripts/setup_glm.sh
+++ b/scripts/setup_glm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Setup GLM environment and directories
+set -e
+
+# install Python dependencies
+pip install -r requirements.txt
+
+# create directories for data and logs
+mkdir -p /INANNA_AI
+mkdir -p /QNL_LANGUAGE
+mkdir -p /audit_logs
+
+# placeholder ethical guideline files
+cat <<'EON' > /INANNA_AI/ETHICS_PLACEHOLDER.txt
+This directory stores INANNA_AI assets.
+Ensure all data complies with ethical guidelines.
+EON
+
+cat <<'EON' > /QNL_LANGUAGE/ETHICS_PLACEHOLDER.txt
+This directory holds QNL language resources.
+Use responsibly and respect copyright.
+EON
+
+cat <<'EON' > /audit_logs/README.txt
+Audit logs for monitoring system behavior.
+EON
+
+printf "Setup complete.\n"

--- a/scripts/setup_repo.sh
+++ b/scripts/setup_repo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Clone a GitHub repository into /INANNA_AI/repo using GITHUB_TOKEN
+set -e
+
+REPO="$1"
+
+if [ -z "$REPO" ]; then
+    echo "Usage: $0 <owner/repo>" >&2
+    exit 1
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN environment variable not set" >&2
+    exit 1
+fi
+
+mkdir -p /INANNA_AI
+rm -rf /INANNA_AI/repo
+
+git clone https://$GITHUB_TOKEN@github.com/$REPO.git /INANNA_AI/repo
+
+echo "Repository cloned on $(date)" > /INANNA_AI/repo/confirmation.txt


### PR DESCRIPTION
## Summary
- add `setup_glm.sh` to install Python packages and set up core folders
- add `setup_repo.sh` to clone a GitHub repository into `/INANNA_AI/repo`
- document both scripts in `VAST_DEPLOYMENT.md`

## Testing
- `bash -n scripts/setup_glm.sh`
- `bash -n scripts/setup_repo.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e79fe7d38832ea92dd3b2ebdd551b