### PR TITLE
Add GLM_API_URL setting

### DIFF
--- a/INANNA_AI/glm_analyze.py
+++ b/INANNA_AI/glm_analyze.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import os
 
 try:  # pragma: no cover - optional dependency
     import requests
@@ -15,7 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 CODE_DIR = ROOT / "inanna_ai"
 AUDIT_DIR = ROOT / "audit_logs"
 ANALYSIS_FILE = AUDIT_DIR / "code_analysis.txt"
-ENDPOINT = "https://api.example.com/glm"
+ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm")
 
 
 def analyze_code() -> str:

--- a/INANNA_AI/glm_init.py
+++ b/INANNA_AI/glm_init.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import os
 
 try:  # pragma: no cover - optional dependency
     import requests
@@ -16,7 +17,7 @@ README_FILE = ROOT / "README.md"
 QNL_DIR = ROOT / "QNL_LANGUAGE"
 AUDIT_DIR = ROOT / "audit_logs"
 PURPOSE_FILE = AUDIT_DIR / "purpose.txt"
-ENDPOINT = "https://api.example.com/glm"
+ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm")
 
 
 def summarize_purpose() -> str:

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -62,6 +62,9 @@ Use `--skip-network` to disable traffic monitoring.
    the chat agent.
 2. Run `python download_models.py deepseek` to fetch the DeepSeek-R1 model.
 3. Start chat via `python INANNA_AI_AGENT/inanna_ai.py chat` or `./run_inanna.sh`.
+4. Optionally set `GLM_API_URL` to point at your GLM endpoint. The helper
+   defaults to `https://api.example.com/glm41v_9b` and uses `GLM_API_KEY` if
+   provided.
 
 ## Download Models
 

--- a/docs/ALBEDO_LAYER.md
+++ b/docs/ALBEDO_LAYER.md
@@ -13,11 +13,11 @@ The **Albedo** layer introduces a small state machine that drives responses thro
 
 ## Configuring the GLM endpoint
 
-The endpoint URL is defined in `glm_integration.ENDPOINT`. Set the environment variable `GLM_ENDPOINT` to override it or edit the constant directly. Provide your API key via `GLM_API_KEY`:
+The endpoint URL is defined in `glm_integration.ENDPOINT`. Set the environment variable `GLM_API_URL` to override it or edit the constant directly. Provide your API key via `GLM_API_KEY`:
 
 ```bash
 export GLM_API_KEY=<your key>
-export GLM_ENDPOINT=https://api.example.com/glm41v_9b
+export GLM_API_URL=https://api.example.com/glm41v_9b
 ```
 
 The helper attaches the key as an `Authorization` header when present.
@@ -28,7 +28,7 @@ To engage the Albedo personality, create the layer and pass it to the orchestrat
 
 ```bash
 export GLM_API_KEY=<your key>
-export GLM_ENDPOINT=https://api.example.com/glm41v_9b
+export GLM_API_URL=https://api.example.com/glm41v_9b
 python -m inanna_ai.main --duration 3
 ```
 

--- a/inanna_ai/existential_reflector.py
+++ b/inanna_ai/existential_reflector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import os
 
 try:  # pragma: no cover - optional dependency
     import requests
@@ -16,7 +17,7 @@ INANNA_DIR = ROOT / "INANNA_AI"
 QNL_DIR = ROOT / "QNL_LANGUAGE"
 AUDIT_DIR = ROOT / "audit_logs"
 INSIGHTS_FILE = AUDIT_DIR / "existential_insights.txt"
-ENDPOINT = "https://api.example.com/glm"
+ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm")
 
 
 class ExistentialReflector:

--- a/inanna_ai/personality_layers/albedo/glm_integration.py
+++ b/inanna_ai/personality_layers/albedo/glm_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Wrapper around a placeholder GLM-4.1V-9B endpoint."""
 
 import logging
+import os
 
 try:  # pragma: no cover - optional dependency
     import requests
@@ -11,7 +12,7 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 logger = logging.getLogger(__name__)
 
-ENDPOINT = "https://api.example.com/glm41v_9b"
+ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm41v_9b")
 
 
 def generate_completion(prompt: str) -> str:

--- a/tests/test_albedo_layer.py
+++ b/tests/test_albedo_layer.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import importlib
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -53,3 +54,9 @@ def test_prompt_construction(monkeypatch):
     layer = AlbedoPersonalityLayer()
     layer.generate_response("hello")
     assert prompts == ["A hello"]
+
+
+def test_env_overrides_endpoint(monkeypatch):
+    monkeypatch.setenv("GLM_API_URL", "http://foo")
+    gi = importlib.reload(glm_integration)
+    assert gi.ENDPOINT == "http://foo"

--- a/tests/test_albedo_personality.py
+++ b/tests/test_albedo_personality.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import importlib
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -66,3 +67,9 @@ def test_prompt_formatting_and_glm(monkeypatch):
     assert [out1, out2, out3] == ["one", "two", "three"]
     assert prompts == ["N-hi", "A-hi", "R-hi"]
     assert layer.state == "rubedo"
+
+
+def test_env_overrides_endpoint(monkeypatch):
+    monkeypatch.setenv("GLM_API_URL", "http://foo")
+    gi = importlib.reload(glm_integration)
+    assert gi.ENDPOINT == "http://foo"

--- a/tests/test_glm_modules.py
+++ b/tests/test_glm_modules.py
@@ -1,6 +1,7 @@
 import sys
 from types import ModuleType
 from pathlib import Path
+import importlib
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -60,3 +61,11 @@ def test_glm_analyze_code(tmp_path, monkeypatch):
     analysis = glm_analyze.analyze_code()
     assert analysis == 'ok'
     assert (out_dir / 'code_analysis.txt').read_text() == 'ok'
+
+
+def test_env_overrides_endpoint(monkeypatch):
+    monkeypatch.setenv('GLM_API_URL', 'http://test/endpoint')
+    gi = importlib.reload(glm_init)
+    ga = importlib.reload(glm_analyze)
+    assert gi.ENDPOINT == 'http://test/endpoint'
+    assert ga.ENDPOINT == 'http://test/endpoint'


### PR DESCRIPTION
## Summary
- make GLM endpoints configurable via `GLM_API_URL`
- document the new variable in ALBEDO_LAYER and operator README
- test that modules and personalities honor the env var

## Testing
- `pytest tests/test_glm_modules.py tests/test_albedo_layer.py tests/test_albedo_personality.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb1dc9ccc832ea082fa8d4d9462ca