### PR TITLE
Add robust error handling around GLM HTTP calls

### DIFF
--- a/INANNA_AI/glm_analyze.py
+++ b/INANNA_AI/glm_analyze.py
@@ -36,7 +36,12 @@ def analyze_code() -> str:
 
     data = {"text": "\n".join(snippets)}
     AUDIT_DIR.mkdir(parents=True, exist_ok=True)
-    resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+    try:
+        resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("Failed to query %s: %s", ENDPOINT, exc)
+        raise
     try:
         analysis = resp.json().get("analysis", "")
     except Exception:  # pragma: no cover - non-json response

--- a/INANNA_AI/glm_init.py
+++ b/INANNA_AI/glm_init.py
@@ -39,7 +39,12 @@ def summarize_purpose() -> str:
 
     data = {"text": "\n".join(texts)}
     AUDIT_DIR.mkdir(parents=True, exist_ok=True)
-    resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+    try:
+        resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("Failed to query %s: %s", ENDPOINT, exc)
+        raise
     try:
         summary = resp.json().get("summary", "")
     except Exception:  # pragma: no cover - non-json response

--- a/inanna_ai/existential_reflector.py
+++ b/inanna_ai/existential_reflector.py
@@ -42,7 +42,13 @@ class ExistentialReflector:
 
         data = {"text": "\n".join(texts)}
         AUDIT_DIR.mkdir(parents=True, exist_ok=True)
-        resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+        try:
+            resp = requests.post(ENDPOINT, json=data, timeout=10, headers=HEADERS)
+            resp.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            logger.error("Failed to query %s: %s", ENDPOINT, exc)
+            raise
+
         try:
             desc = resp.json().get("description", "")
         except Exception:  # pragma: no cover - non-json response

--- a/inanna_ai/personality_layers/albedo/glm_integration.py
+++ b/inanna_ai/personality_layers/albedo/glm_integration.py
@@ -22,7 +22,13 @@ def generate_completion(prompt: str) -> str:
     if requests is None:
         raise RuntimeError("requests library is required")
 
-    resp = requests.post(ENDPOINT, json={"prompt": prompt}, timeout=10, headers=HEADERS)
+    try:
+        resp = requests.post(ENDPOINT, json={"prompt": prompt}, timeout=10, headers=HEADERS)
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        logger.error("Failed to query %s: %s", ENDPOINT, exc)
+        raise
+
     try:
         text = resp.json().get("text", "")
     except Exception:  # pragma: no cover - non-json response

--- a/tests/test_existential_reflector.py
+++ b/tests/test_existential_reflector.py
@@ -16,6 +16,9 @@ class DummyResponse:
     def json(self):
         return self._data
 
+    def raise_for_status(self):
+        return None
+
 
 def test_reflect_on_identity(tmp_path, monkeypatch):
     ina = tmp_path / "INANNA_AI"

--- a/tests/test_glm_modules.py
+++ b/tests/test_glm_modules.py
@@ -2,6 +2,7 @@ import sys
 from types import ModuleType
 from pathlib import Path
 import importlib
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -16,6 +17,9 @@ class DummyResponse:
 
     def json(self):
         return self._data
+
+    def raise_for_status(self):
+        return None
 
 
 def test_glm_init_summarize(tmp_path, monkeypatch):
@@ -109,3 +113,72 @@ def test_glm_headers(monkeypatch, tmp_path):
     ga.analyze_code()
 
     assert seen == [{'Authorization': 'Bearer secret'}, {'Authorization': 'Bearer secret'}]
+
+
+def test_glm_init_error(tmp_path, monkeypatch):
+    readme = tmp_path / 'README.md'
+    qnl = tmp_path / 'QNL_LANGUAGE'
+    qnl.mkdir()
+    readme.write_text('hello', encoding='utf-8')
+    (qnl / 'a.md').write_text('world', encoding='utf-8')
+
+    out_dir = tmp_path / 'audit_logs'
+
+    monkeypatch.setattr(glm_init, 'ROOT', tmp_path)
+    monkeypatch.setattr(glm_init, 'README_FILE', readme)
+    monkeypatch.setattr(glm_init, 'QNL_DIR', qnl)
+    monkeypatch.setattr(glm_init, 'AUDIT_DIR', out_dir)
+    monkeypatch.setattr(glm_init, 'PURPOSE_FILE', out_dir / 'purpose.txt')
+
+    class DummyExc(Exception):
+        pass
+
+    class ErrorResp:
+        text = 'bad'
+
+        def json(self):
+            return {'summary': 'bad'}
+
+        def raise_for_status(self):
+            raise DummyExc('fail')
+
+    dummy = ModuleType('requests')
+    dummy.RequestException = DummyExc
+    dummy.post = lambda *a, **k: ErrorResp()
+    monkeypatch.setattr(glm_init, 'requests', dummy)
+
+    with pytest.raises(DummyExc):
+        glm_init.summarize_purpose()
+
+
+def test_glm_analyze_error(tmp_path, monkeypatch):
+    code_dir = tmp_path / 'inanna_ai'
+    code_dir.mkdir()
+    (code_dir / 'x.py').write_text('print(1)', encoding='utf-8')
+
+    out_dir = tmp_path / 'audit_logs'
+
+    monkeypatch.setattr(glm_analyze, 'ROOT', tmp_path)
+    monkeypatch.setattr(glm_analyze, 'CODE_DIR', code_dir)
+    monkeypatch.setattr(glm_analyze, 'AUDIT_DIR', out_dir)
+    monkeypatch.setattr(glm_analyze, 'ANALYSIS_FILE', out_dir / 'code_analysis.txt')
+
+    class DummyExc(Exception):
+        pass
+
+    class ErrorResp:
+        text = 'bad'
+
+        def json(self):
+            return {'analysis': 'bad'}
+
+        def raise_for_status(self):
+            raise DummyExc('fail')
+
+    dummy = ModuleType('requests')
+    dummy.RequestException = DummyExc
+    dummy.post = lambda *a, **k: ErrorResp()
+    monkeypatch.setattr(glm_analyze, 'requests', dummy)
+
+    with pytest.raises(DummyExc):
+        glm_analyze.analyze_code()


### PR DESCRIPTION
## Summary
- raise errors for failed HTTP calls in GLM integration modules
- log and re‑raise request failures
- support new behaviour in unit tests
- cover non‑200 responses in GLM module tests

## Testing
- `pytest tests/test_glm_modules.py -q`
- `pytest tests/test_existential_reflector.py -q`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ebdfdc82c832e9fd2d1ff8e8a62e0