### PR TITLE
Encapsulate GLM settings

### DIFF
--- a/inanna_ai/personality_layers/albedo/__init__.py
+++ b/inanna_ai/personality_layers/albedo/__init__.py
@@ -10,9 +10,13 @@ from . import state_contexts
 class AlbedoPersonality:
     """Generate text according to the current alchemical state."""
 
-    def __init__(self, glm: GLMIntegration | None = None, persona: AlchemicalPersona | None = None) -> None:
+    def __init__(
+        self,
+        integration: GLMIntegration | None = None,
+        persona: AlchemicalPersona | None = None,
+    ) -> None:
         self._persona = persona or AlchemicalPersona()
-        self._glm = glm or GLMIntegration()
+        self._glm = integration or GLMIntegration()
 
     @property
     def state(self) -> str:

--- a/inanna_ai/personality_layers/albedo/glm_integration.py
+++ b/inanna_ai/personality_layers/albedo/glm_integration.py
@@ -12,17 +12,26 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 logger = logging.getLogger(__name__)
 
-ENDPOINT = os.getenv("GLM_API_URL", "https://api.example.com/glm41v_9b")
-API_KEY = os.getenv("GLM_API_KEY")
+DEFAULT_ENDPOINT = "https://api.example.com/glm41v_9b"
 SAFE_ERROR_MESSAGE = "GLM unavailable"
 
 
 class GLMIntegration:
     """Small wrapper around a GLM endpoint."""
 
-    def __init__(self, endpoint: str | None = None, api_key: str | None = None, temperature: float = 0.8) -> None:
-        self.endpoint = endpoint or ENDPOINT
-        self.api_key = api_key or API_KEY
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        api_key: str | None = None,
+        temperature: float = 0.8,
+    ) -> None:
+        """Initialize from arguments or environment variables."""
+        if endpoint is None:
+            endpoint = os.getenv("GLM_API_URL", DEFAULT_ENDPOINT)
+        if api_key is None:
+            api_key = os.getenv("GLM_API_KEY")
+        self.endpoint = endpoint
+        self.api_key = api_key
         self.temperature = temperature
 
     @property
@@ -39,7 +48,9 @@ class GLMIntegration:
 
         payload = {"prompt": prompt, "temperature": self.temperature}
         try:
-            resp = requests.post(self.endpoint, json=payload, timeout=10, headers=self.headers)
+            resp = requests.post(
+                self.endpoint, json=payload, timeout=10, headers=self.headers
+            )
             resp.raise_for_status()
         except requests.RequestException as exc:  # pragma: no cover - network errors
             logger.error("Failed to query %s: %s", self.endpoint, exc)
@@ -52,4 +63,4 @@ class GLMIntegration:
         return text or SAFE_ERROR_MESSAGE
 
 
-__all__ = ["GLMIntegration", "ENDPOINT", "SAFE_ERROR_MESSAGE"]
+__all__ = ["GLMIntegration", "DEFAULT_ENDPOINT", "SAFE_ERROR_MESSAGE"]

--- a/tests/test_albedo_layer.py
+++ b/tests/test_albedo_layer.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from pathlib import Path
-import importlib
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -76,16 +75,15 @@ def test_prompt_construction(monkeypatch):
 
 def test_env_overrides_endpoint(monkeypatch):
     monkeypatch.setenv("GLM_API_URL", "http://foo")
-    gi = importlib.reload(glm_integration)
-    assert gi.ENDPOINT == "http://foo"
+    gi = GLMIntegration()
+    assert gi.endpoint == "http://foo"
 
 
 def test_glm_header(monkeypatch):
     prompts = []
     monkeypatch.setenv("GLM_API_KEY", "tok")
-    gi = importlib.reload(glm_integration)
     _patch_requests(monkeypatch, prompts)
-    GLMIntegration(api_key="tok", endpoint=gi.ENDPOINT).complete("hello")
+    GLMIntegration().complete("hello")
     assert prompts == [("hello", {"Authorization": "Bearer tok"})]
 
 
@@ -106,9 +104,8 @@ def test_env_vars_honored(monkeypatch):
     calls = []
     monkeypatch.setenv("GLM_API_URL", "http://bar")
     monkeypatch.setenv("GLM_API_KEY", "key")
-    gi = importlib.reload(glm_integration)
     _patch_requests_capture(monkeypatch, calls)
-    GLMIntegration(endpoint=gi.ENDPOINT, api_key="key").complete("yo")
+    GLMIntegration().complete("yo")
     assert calls == [("http://bar", "yo", {"Authorization": "Bearer key"})]
 
 
@@ -124,13 +121,11 @@ def test_glm_error_safe_message(monkeypatch):
 
     dummy.post = post
     monkeypatch.setattr(glm_integration, "requests", dummy)
-    gi = importlib.reload(glm_integration)
-    out = GLMIntegration(endpoint=gi.ENDPOINT).complete("hi")
+    out = GLMIntegration().complete("hi")
     assert out == glm_integration.SAFE_ERROR_MESSAGE
 
 
 def test_glm_missing_requests(monkeypatch):
     monkeypatch.setattr(glm_integration, "requests", None)
-    gi = importlib.reload(glm_integration)
-    out = GLMIntegration(endpoint=gi.ENDPOINT).complete("hi")
+    out = GLMIntegration().complete("hi")
     assert out == glm_integration.SAFE_ERROR_MESSAGE

--- a/tests/test_albedo_personality.py
+++ b/tests/test_albedo_personality.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from pathlib import Path
-import importlib
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -9,6 +8,7 @@ sys.path.insert(0, str(ROOT))
 from inanna_ai.personality_layers.albedo import (
     AlbedoPersonality,
     AlchemicalPersona,
+    GLMIntegration,
     State,
     glm_integration,
     state_contexts,
@@ -76,5 +76,5 @@ def test_prompt_formatting_and_glm(monkeypatch):
 
 def test_env_overrides_endpoint(monkeypatch):
     monkeypatch.setenv("GLM_API_URL", "http://foo")
-    gi = importlib.reload(glm_integration)
-    assert gi.ENDPOINT == "http://foo"
+    gi = GLMIntegration()
+    assert gi.endpoint == "http://foo"


### PR DESCRIPTION
## Summary
- move API config into `GLMIntegration.__init__`
- allow `AlbedoPersonality` to receive a `GLMIntegration` instance
- update tests to construct integration objects after setting env vars

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6870e0f0ba7c832e87985179dd6405ef