### PR TITLE
Enable dynamic personality layers

### DIFF
--- a/inanna_ai/main.py
+++ b/inanna_ai/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from orchestrator import MoGEOrchestrator
-from .personality_layers import AlbedoPersonality
+from .personality_layers import REGISTRY
 from .rfa_7d import RFA7D
 from .gate_orchestrator import GateOrchestrator
 from .love_matrix import LoveMatrix
@@ -40,15 +40,17 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--duration", type=float, default=3.0, help="Recording length in seconds")
     parser.add_argument(
         "--personality",
-        choices=["albedo"],
-        help="Activate optional personality layer",
+        choices=sorted(REGISTRY),
+        help=(
+            "Activate optional personality layer. "
+            f"Available: {', '.join(sorted(REGISTRY))}"
+        ),
     )
     args = parser.parse_args(argv)
 
-    if args.personality == "albedo":
-        orchestrator = MoGEOrchestrator(albedo_layer=AlbedoPersonality())
-    else:
-        orchestrator = MoGEOrchestrator()
+    layer_cls = REGISTRY.get(args.personality)
+    layer = layer_cls() if layer_cls else None
+    orchestrator = MoGEOrchestrator(albedo_layer=layer)
     gate = GateOrchestrator()
     core = RFA7D()
     speaker = speaking_engine.SpeakingEngine()

--- a/inanna_ai/personality_layers/__init__.py
+++ b/inanna_ai/personality_layers/__init__.py
@@ -1,5 +1,32 @@
 """Personality layers for INANNA AI."""
 
+from __future__ import annotations
+
+from importlib import import_module
+from pkgutil import iter_modules
+from typing import Dict, Type
+
 from .albedo import AlbedoPersonality
 
-__all__ = ["AlbedoPersonality"]
+REGISTRY: Dict[str, Type] = {"albedo": AlbedoPersonality}
+
+for mod in iter_modules(__path__):
+    if not mod.ispkg or mod.name == "albedo":
+        continue
+    module = import_module(f"{__name__}.{mod.name}")
+    cls = None
+    if hasattr(module, "__all__"):
+        for name in module.__all__:
+            if name.endswith("Personality"):
+                cls = getattr(module, name, None)
+                if cls:
+                    break
+    if cls is None:
+        for attr in dir(module):
+            if attr.endswith("Personality"):
+                cls = getattr(module, attr)
+                break
+    if cls is not None:
+        REGISTRY[mod.name] = cls
+
+__all__ = ["AlbedoPersonality", "REGISTRY"]

--- a/tests/test_inanna_ai.py
+++ b/tests/test_inanna_ai.py
@@ -290,7 +290,7 @@ def test_personality_flag_initializes_layer(monkeypatch):
         created["layer"] = True
         return DummyLayer()
 
-    monkeypatch.setattr(voice_main, "AlbedoPersonality", make_layer)
+    monkeypatch.setattr(voice_main, "REGISTRY", {"albedo": make_layer})
 
     class DummyOrch:
         def __init__(self, *, albedo_layer=None):

--- a/tests/test_personality_layers.py
+++ b/tests/test_personality_layers.py
@@ -1,0 +1,85 @@
+import types
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import main as voice_main
+import pytest
+
+
+class DummyLayerA:
+    pass
+
+class DummyLayerB:
+    pass
+
+
+def setup_basic(monkeypatch):
+    monkeypatch.setattr(voice_main.utils, "setup_logger", lambda: None)
+    monkeypatch.setattr(voice_main.db_storage, "init_db", lambda: None)
+    monkeypatch.setattr(voice_main.db_storage, "save_interaction", lambda *a, **k: None)
+
+    class DummyEngine:
+        def record(self, duration):
+            return "a.wav", {"emotion": "calm"}
+
+    monkeypatch.setattr(voice_main.listening_engine, "ListeningEngine", lambda: DummyEngine())
+    monkeypatch.setattr(voice_main.stt_whisper, "transcribe_audio", lambda p: "hi")
+
+    class DummyGate:
+        def process_inward(self, text):
+            return ["vec"]
+
+        def process_outward(self, grid):
+            return "gate"
+
+    monkeypatch.setattr(voice_main, "GateOrchestrator", lambda: DummyGate())
+    monkeypatch.setattr(
+        voice_main,
+        "RFA7D",
+        lambda: type("C", (), {"execute": lambda self, v: [1], "grid": type("G", (), {"size": 1})()})(),
+    )
+    monkeypatch.setattr(
+        voice_main.speaking_engine,
+        "SpeakingEngine",
+        lambda: type("S", (), {"speak": lambda self, t, e: "v.wav"})(),
+    )
+
+
+def test_registry_multiple_layers(monkeypatch):
+    setup_basic(monkeypatch)
+    created = {}
+
+    def make_a():
+        created["a"] = True
+        return DummyLayerA()
+
+    def make_b():
+        created["b"] = True
+        return DummyLayerB()
+
+    monkeypatch.setattr(voice_main, "REGISTRY", {"a": make_a, "b": make_b})
+
+    class DummyOrch:
+        def __init__(self, *, albedo_layer=None):
+            created["layer"] = albedo_layer
+
+        def route(self, *a, **k):
+            return {"text": "reply"}
+
+    monkeypatch.setattr(voice_main, "MoGEOrchestrator", DummyOrch)
+
+    voice_main.main(["--duration", "0", "--personality", "b"])
+
+    assert created.get("b")
+    assert isinstance(created.get("layer"), DummyLayerB)
+
+
+def test_help_lists_layers(monkeypatch, capsys):
+    monkeypatch.setattr(voice_main, "REGISTRY", {"a": DummyLayerA, "b": DummyLayerB})
+    with pytest.raises(SystemExit):
+        voice_main.main(["--help"])
+    out = capsys.readouterr().out
+    assert "a" in out and "b" in out


### PR DESCRIPTION
## Summary
- scan `inanna_ai.personality_layers` for available personalities
- expose registry of layers in `personality_layers.__init__`
- load chosen personality dynamically in CLI
- update CLI help text with available layers
- test registry functionality and CLI layer selection

## Testing
- `pytest tests/test_inanna_ai.py::test_personality_flag_initializes_layer tests/test_personality_layers.py -q`
- `pytest -q` *(fails: soundfile.LibsndfileError, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870e2e521fc832e84c9625dde8e36ea