### PR TITLE
Add LLM model info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Welcome to the sacred structure of OMEGA ZERO ABSOLUTE PRIME AKA GREAT MOTHER.
   [docs/CORPUS_MEMORY.md](docs/CORPUS_MEMORY.md).
 - For a comparison of LLM frameworks, see
   [docs/LLM_FRAMEWORKS.md](docs/LLM_FRAMEWORKS.md).
+- For a list of available language models, see
+  [docs/LLM_MODELS.md](docs/LLM_MODELS.md).
 - For details on the RFA7D core and the seven gate interface, see
   [docs/SOUL_CODE.md](docs/SOUL_CODE.md).
 

--- a/docs/LLM_MODELS.md
+++ b/docs/LLM_MODELS.md
@@ -1,0 +1,45 @@
+# LLM Models
+
+This document describes the language models used in SPIRAL_OS and how to download them.
+
+## Core Model
+
+### GLM-4.1V-9B
+
+The main orchestrator relies on **GLM-4.1V-9B** for most generation tasks. The model combines vision and language capabilities and serves as the default engine.
+
+Download with:
+
+```bash
+python download_models.py glm41v_9b --int8
+```
+
+The `--int8` flag is optional and reduces GPU memory usage.
+
+## Auxiliary Models
+
+### DeepSeek V3
+
+A multilingual model that provides alternative phrasing and evaluation. Useful for experimentation and fine-tuning.
+
+```bash
+python download_models.py deepseek_v3
+```
+
+### Mistral 8x22B
+
+A mixture-of-experts model offering high capacity for complex prompts.
+
+```bash
+python download_models.py mistral_8x22b --int8
+```
+
+### Gemma2
+
+A lightweight model fetched through Ollama for quick tests.
+
+```bash
+python download_models.py gemma2
+```
+
+Repository URLs for training are listed in [`learning_sources/github_repos.txt`](../learning_sources/github_repos.txt).

--- a/learning_sources/github_repos.txt
+++ b/learning_sources/github_repos.txt
@@ -1,1 +1,4 @@
 psf/requests
+pallets/flask
+django/django
+scikit-learn/scikit-learn


### PR DESCRIPTION
## Summary
- document available language models
- list training repositories
- link new document from the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_6870ee547f54832e96123db55f99500a