### PR TITLE
Add GitHub and Gutenberg tests

### DIFF
--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import base64
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.learning import github_scraper as gs
+
+
+def test_fetch_repo_saves_readme(monkeypatch, tmp_path):
+    content = "hello"
+    encoded = base64.b64encode(content.encode()).decode()
+
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+        def json(self):
+            return {"content": encoded}
+
+    monkeypatch.setattr(gs, "_headers", lambda: {})
+    dummy_req = types.ModuleType("requests")
+    dummy_req.get = lambda *a, **k: DummyResp()
+    monkeypatch.setattr(gs, "requests", dummy_req)
+
+    paths = gs.fetch_repo("psf/requests", dest_dir=tmp_path)
+    expected = tmp_path / "psf_requests_README.md"
+    assert paths == [expected]
+    assert expected.read_text() == content
+
+
+def test_fetch_all_uses_repo_list(monkeypatch, tmp_path):
+    repos = ["a/b", "c/d"]
+    monkeypatch.setattr(gs, "load_repo_list", lambda p=None: repos)
+
+    saved = []
+    def dummy_fetch_repo(repo, dest_dir=None):
+        path = tmp_path / f"{repo.replace('/', '_')}.md"
+        path.write_text(repo, encoding="utf-8")
+        saved.append(repo)
+        return [path]
+
+    monkeypatch.setattr(gs, "fetch_repo", dummy_fetch_repo)
+
+    files = gs.fetch_all(Path("dummy"))
+    assert saved == repos
+    assert len(files) == 2

--- a/tests/test_project_gutenberg.py
+++ b/tests/test_project_gutenberg.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+import types
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai.learning import project_gutenberg as pg
+
+
+def test_search_parses_results(monkeypatch):
+    html = """
+    <li class='booklink'>
+      <a href='/ebooks/123'></a>
+      <span class='title'>Title A</span>
+    </li>
+    <li class='booklink'>
+      <a href='/ebooks/456'></a>
+      <span class='title'>Title B</span>
+    </li>
+    """
+    class DummyResp:
+        text = html
+        def raise_for_status(self):
+            return None
+
+    dummy_req = types.ModuleType("requests")
+    dummy_req.get = lambda *a, **k: DummyResp()
+    dummy_req.utils = types.SimpleNamespace(quote=lambda q: q)
+    monkeypatch.setattr(pg, "requests", dummy_req)
+
+    class DummySoup:
+        def __init__(self, text):
+            self.text = text
+
+        def select(self, selector):
+            matches = re.findall(r"<a href='/ebooks/(\d+)'></a>\s*<span class='title'>([^<]+)", self.text)
+            books = []
+            for book_id, title in matches:
+                class Book:
+                    def __init__(self, bid, t):
+                        self.bid = bid
+                        self.title = t
+
+                    def find(self, tag, href=False, class_=None):
+                        if tag == "a" and href:
+                            return {"href": f"/{self.bid}"}
+                        if tag == "span" and class_ == "title":
+                            return types.SimpleNamespace(get_text=lambda strip=True: self.title)
+                        return None
+
+                books.append(Book(book_id, title))
+            return books
+
+    monkeypatch.setattr(pg, "BeautifulSoup", lambda text, parser: DummySoup(text))
+    results = pg.search("foo", max_results=2)
+    assert results == [("123", "Title A"), ("456", "Title B")]
+
+
+def test_download_tries_patterns(monkeypatch, tmp_path):
+    calls = []
+    def dummy_download(url, dest):
+        calls.append(url)
+        if url.endswith("-0.txt"):
+            raise RuntimeError("fail")
+        dest.write_text("content", encoding="utf-8")
+        return dest
+    monkeypatch.setattr(pg, "_download_file", dummy_download)
+    path = pg.download("789", dest_dir=tmp_path)
+    assert path.read_text() == "content"
+    assert calls[0].endswith("789-0.txt")
+    assert any(url.endswith(".txt") for url in calls)
+
+
+def test_chunk_respects_token_limit():
+    text = " ".join(str(i) for i in range(10))
+    chunks = pg.chunk(text, max_tokens=3)
+    assert all(len(c.split()) <= 3 for c in chunks)
+    assert " ".join(chunks) == text


### PR DESCRIPTION
## Summary
- add test_project_gutenberg for search, download and chunking
- add test_github_scraper for GitHub API fetching logic

## Testing
- `pytest tests/test_learning.py tests/test_project_gutenberg.py tests/test_github_scraper.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870efd81e8c832ea9fb152e4b05085f