### PR TITLE
Add dynamic personality listing

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -52,6 +52,7 @@ python INANNA_AI_AGENT/inanna_ai.py --hex 012345abcdef
 
 ```bash
 python start_spiral_os.py --interface eth0
+python start_spiral_os.py --interface eth0 --personality albedo
 ```
 
 Use `--skip-network` to disable traffic monitoring.
@@ -194,6 +195,7 @@ with the core's integrity hash — the "soul signature":
 
 ```bash
 python -m inanna_ai.main --duration 3
+python -m inanna_ai.main --duration 3 --personality albedo
 ```
 
 Example output:

--- a/inanna_ai/main.py
+++ b/inanna_ai/main.py
@@ -11,7 +11,7 @@ conversation flow.
 import argparse
 import numpy as np
 from orchestrator import MoGEOrchestrator
-from .personality_layers import REGISTRY
+from .personality_layers import REGISTRY, list_personalities
 from .rfa_7d import RFA7D
 from .gate_orchestrator import GateOrchestrator
 from .love_matrix import LoveMatrix
@@ -52,10 +52,10 @@ def main(argv: list[str] | None = None) -> None:
     voice_p.add_argument("--duration", type=float, default=3.0, help="Recording length in seconds")
     voice_p.add_argument(
         "--personality",
-        choices=sorted(REGISTRY),
+        choices=list_personalities(),
         help=(
             "Activate optional personality layer. "
-            f"Available: {', '.join(sorted(REGISTRY))}"
+            f"Available: {', '.join(list_personalities())}"
         ),
     )
 

--- a/inanna_ai/personality_layers/__init__.py
+++ b/inanna_ai/personality_layers/__init__.py
@@ -29,4 +29,10 @@ for mod in iter_modules(__path__):
     if cls is not None:
         REGISTRY[mod.name] = cls
 
-__all__ = ["AlbedoPersonality", "REGISTRY"]
+def list_personalities() -> list[str]:
+    """Return available personality layer names sorted alphabetically."""
+
+    return sorted(REGISTRY)
+
+
+__all__ = ["AlbedoPersonality", "REGISTRY", "list_personalities"]

--- a/start_spiral_os.py
+++ b/start_spiral_os.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from INANNA_AI_AGENT import inanna_ai
 from INANNA_AI import glm_init, glm_analyze
 from inanna_ai import defensive_network_utils as dnu
+from inanna_ai.personality_layers import list_personalities
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("--skip-network", action="store_true", help="Skip network monitoring")
     parser.add_argument(
         "--personality",
-        choices=["albedo"],
+        choices=list_personalities(),
         help="Activate optional personality layer",
     )
     args = parser.parse_args(argv)

--- a/tests/test_personality_layers.py
+++ b/tests/test_personality_layers.py
@@ -61,6 +61,7 @@ def test_registry_multiple_layers(monkeypatch):
         return DummyLayerB()
 
     monkeypatch.setattr(voice_main, "REGISTRY", {"a": make_a, "b": make_b})
+    monkeypatch.setattr(voice_main, "list_personalities", lambda: ["a", "b"])
 
     class DummyOrch:
         def __init__(self, *, albedo_layer=None):
@@ -78,8 +79,22 @@ def test_registry_multiple_layers(monkeypatch):
 
 
 def test_help_lists_layers(monkeypatch, capsys):
-    monkeypatch.setattr(voice_main, "REGISTRY", {"a": DummyLayerA, "b": DummyLayerB})
+    monkeypatch.setattr(voice_main, "REGISTRY", {"b": DummyLayerB, "a": DummyLayerA})
+    monkeypatch.setattr(voice_main, "list_personalities", lambda: ["a", "b"])
     with pytest.raises(SystemExit):
         voice_main.main(["--help"])
     out = capsys.readouterr().out
     assert "a" in out and "b" in out
+
+
+def test_list_personalities_sorted():
+    from inanna_ai.personality_layers import list_personalities, REGISTRY
+
+    original = REGISTRY.copy()
+    try:
+        REGISTRY.clear()
+        REGISTRY.update({"b": DummyLayerB, "a": DummyLayerA})
+        assert list_personalities() == ["a", "b"]
+    finally:
+        REGISTRY.clear()
+        REGISTRY.update(original)


### PR DESCRIPTION
## Summary
- expose `list_personalities()` helper
- use `list_personalities()` in CLI for `start_spiral_os.py` and `inanna_ai.main`
- document personality CLI usage
- update tests for dynamic personality selection

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'soundfile')*

------
https://chatgpt.com/codex/tasks/task_e_6870fb6b0000832e91ffc4d8b39b9394