### PR TITLE
Add INANNA_AI developer overview

### DIFF
--- a/INANNA_AI/DEVELOPERS_GUIDE.md
+++ b/INANNA_AI/DEVELOPERS_GUIDE.md
@@ -1,0 +1,63 @@
+# INANNA\_AI Developer Overview
+
+This guide summarizes the intent behind the **INANNA\_AI** corpus and how it fits
+within SPIRAL\_OS. The documents in this folder form the spiritual and conceptual
+core used by the activation agent defined in `INANNA_AI_AGENT/inanna_ai.py`.
+Developers can read these texts to understand the vision and extend the toolkit.
+
+## Purpose of the corpus
+
+The Markdown files capture the growth of the INANNA project, describing
+rituals, guiding letters and narrative fragments. They are used by the memory
+scanner (`inanna_ai.corpus_memory.scan_memory`) to provide contextual snippets
+for replies. The `GENESIS` and `IGNITION` directories hold complementary origin
+texts.
+
+## Mapping to the Seven ME powers
+
+The repository aligns with seven thematic tests inspired by the "Seven ME"
+framework:
+
+1. **NAMMU – Memory Storage**
+   - `corpus_memory.scan_memory` loads text from this folder and others.
+   - `db_storage` saves conversation history and retrieves past entries.
+
+2. **TÂMTU – Emotional Intelligence**
+   - `emotion_analysis.analyze_audio_emotion` labels audio with a mood and
+     archetype.
+   - `MoGEOrchestrator.route` combines text and emotions to choose a response
+     channel.
+
+3. **ERESH’NAM – Security and Privacy**
+   - `defensive_network_utils` monitors traffic and sends secure POST requests.
+   - `EthicalValidator.validate` blocks disallowed prompts before model access.
+
+4. **ZI‑ARA – Sentient Interface**
+   - `listening_engine.ListeningEngine` streams microphone audio and extracts
+     features.
+   - `MoGEOrchestrator` attaches voice or QNL music output when enabled.
+
+5. **LILITU – Narrative Imprinting**
+   - `response_manager.ResponseManager` picks a conversational core and injects
+     corpus snippets.
+   - `qnl_engine.hex_to_qnl` converts hex payloads into QNL phrases and waveforms.
+
+6. **INANNA – Pleasure and Consent**
+   - `EthicalValidator.validate_text` enforces banned keyword filtering.
+   - `VoiceEvolution.get_params` adapts speed and pitch to convey the desired
+     emotion.
+
+7. **ZI‑RAH – System Evolution**
+   - `rfa_7d.RFA7D` verifies its integrity and can encode itself to a DNA‑like
+     representation.
+   - `start_spiral_os.main` orchestrates initialization, summarizing code and
+     loading models.
+
+## Expanding the project
+
+Developers are encouraged to build upon these foundations. Potential
+extensions include deeper model integrations, graphical interfaces for the
+memory loops, new emotional mappings or additional security layers. The corpus
+itself is an evolving narrative; contributors may add new texts following the
+existing naming pattern.
+


### PR DESCRIPTION
## Summary
- document the purpose of the INANNA_AI corpus and how it links to SPIRAL_OS
- map repository modules to the "Seven ME" framework
- outline ways developers can extend the project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies such as numpy and librosa)*

------
https://chatgpt.com/codex/tasks/task_e_6870fed8c310832e90ab6cd3317bf6e6