### PR TITLE
Add model directory option to INANNA AI

### DIFF
--- a/INANNA_AI_AGENT/inanna_ai.py
+++ b/INANNA_AI_AGENT/inanna_ai.py
@@ -167,9 +167,9 @@ def reflect_existence() -> str:
     return desc
 
 
-def chat_loop() -> None:
-    """Interactive chat with the local DeepSeek-R1 model."""
-    mdl, tok = model.load_model(MODEL_PATH)
+def chat_loop(model_dir: str | Path = MODEL_PATH) -> None:
+    """Interactive chat with a local language model."""
+    mdl, tok = model.load_model(model_dir)
     gen_model: GenerationMixin = mdl  # type: ignore[assignment]
     print("Enter 'exit' to quit.")
     while True:
@@ -193,12 +193,18 @@ def main() -> None:
     parser.add_argument("--json", default="qnl_hex_song.json", help="Output metadata JSON for QNL engine")
     parser.add_argument("--list", action="store_true", help="List available source texts")
     subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser("chat", help="Interact with the local model")
+    chat_parser = subparsers.add_parser("chat", help="Interact with the local model")
+    chat_parser.add_argument(
+        "--model-dir",
+        "--model",
+        default=str(MODEL_PATH),
+        help="Path to the local model directory",
+    )
 
     args = parser.parse_args()
 
     if args.command == "chat":
-        chat_loop()
+        chat_loop(Path(args.model_dir))
         return
 
     if args.list:

--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -64,6 +64,8 @@ Use `--skip-network` to disable traffic monitoring.
    the chat agent.
 2. Run `python download_models.py deepseek` to fetch the DeepSeek-R1 model.
 3. Start chat via `python INANNA_AI_AGENT/inanna_ai.py chat` or `./run_inanna.sh`.
+   To load a different model directory pass `--model-dir <path>` to either command,
+   for example `./run_inanna.sh --model-dir INANNA_AI/models/gemma2`.
 4. Optionally configure `GLMIntegration` with your GLM endpoint and API key.  If
    no values are provided the class reads `GLM_API_URL` and `GLM_API_KEY` from
    the environment and defaults to `https://api.example.com/glm41v_9b`.

--- a/run_inanna.sh
+++ b/run_inanna.sh
@@ -15,4 +15,4 @@ if [ ! -d "$MODELS_DIR/DeepSeek-R1" ] && [ ! -d "$MODELS_DIR/gemma2" ]; then
     exit 1
 fi
 
-python INANNA_AI_AGENT/inanna_ai.py chat
+python INANNA_AI_AGENT/inanna_ai.py chat "$@"


### PR DESCRIPTION
## Summary
- make `chat_loop` accept a `model_dir` parameter
- expose `--model-dir/--model` CLI flag and forward it in `run_inanna.sh`
- document custom model selection in README_OPERATOR
- test that chat uses the provided model directory

## Testing
- `pytest tests/test_inanna_ai.py::test_chat_subparser tests/test_inanna_ai.py::test_chat_model_dir_option -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_6871092178f0832e866dc6d07b82dc37