### PR TITLE
Add predictive LLM selector and dashboard

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,20 @@
+import streamlit as st
+import pandas as pd
+from inanna_ai import db_storage, gate_orchestrator
+
+st.set_page_config(page_title="LLM Metrics Dashboard")
+
+st.title("LLM Performance Metrics")
+
+metrics = db_storage.fetch_benchmarks()
+if metrics:
+    df = pd.DataFrame(metrics)
+    st.line_chart(df.set_index("timestamp")[["response_time", "coherence", "relevance"]])
+else:
+    st.write("No benchmark data available.")
+
+predictor = gate_orchestrator.GateOrchestrator()
+pred = predictor.predict_best_llm()
+
+st.markdown(f"**Predicted best model:** `{pred}`")
+

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,15 @@
+# Metrics Dashboard
+
+This dashboard visualises recent model performance and the predicted best LLM.
+
+## Setup
+
+Install dependencies and run the dashboard:
+
+```bash
+pip install -r requirements.txt
+streamlit run dashboard/app.py
+```
+
+The application reads from `inanna_ai/db_storage.py` and updates automatically
+when new benchmarks are logged.

--- a/inanna_ai/gate_orchestrator.py
+++ b/inanna_ai/gate_orchestrator.py
@@ -1,12 +1,29 @@
 """Simple gate orchestrator translating text to/from complex vectors."""
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Deque, Sequence, List
 import numpy as np
 from pathlib import Path
 from time import perf_counter
+from collections import deque
+
+import torch
+from torch import nn
 
 from . import db_storage
+
+
+class _ModelPredictor(nn.Module):
+    """Tiny LSTM model predicting the best LLM."""
+
+    def __init__(self, num_features: int = 4, hidden_size: int = 16, num_models: int = 3) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(num_features, hidden_size, batch_first=True)
+        self.fc = nn.Linear(hidden_size, num_models)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - depends on torch
+        out, _ = self.lstm(x)
+        return self.fc(out[:, -1])
 
 
 class GateOrchestrator:
@@ -14,6 +31,12 @@ class GateOrchestrator:
 
     def __init__(self, *, db_path: Path | None = None) -> None:
         self._db_path = db_path or db_storage.DB_PATH
+        self._context: Deque[List[float]] = deque(maxlen=5)
+        self._predictor = _ModelPredictor()
+        self._selection_weights = np.ones(3, dtype=float)
+        self._seq_len = 3
+        self._train_predictor()
+        self._optimize_parameters()
 
     def process_inward(self, text: str) -> Sequence[complex]:
         """Convert ``text`` to a complex vector of length 128."""
@@ -44,6 +67,76 @@ class GateOrchestrator:
             return 0.0
         return len(src & gen) / len(src | gen)
 
+    def _load_training_data(self) -> tuple[torch.Tensor, torch.Tensor] | tuple[None, None]:
+        metrics = db_storage.fetch_benchmarks(limit=50, db_path=self._db_path)
+        interactions = db_storage.fetch_interactions(limit=50, db_path=self._db_path)
+        n = min(len(metrics), len(interactions))
+        if n <= self._seq_len:
+            return None, None
+        metrics = list(reversed(metrics[:n]))
+        interactions = list(reversed(interactions[:n]))
+
+        model_to_idx = {"glm": 0, "deepseek": 1, "mistral": 2, "gate": 0}
+        seqs: List[List[List[float]]] = []
+        labels: List[int] = []
+        for i in range(self._seq_len, n):
+            seq: List[List[float]] = []
+            for j in range(i - self._seq_len, i):
+                m = metrics[j]
+                length = len(interactions[j]["transcript"])
+                seq.append([m["response_time"], m["coherence"], m["relevance"], float(length)])
+            seqs.append(seq)
+            labels.append(model_to_idx.get(metrics[i]["model"], 0))
+
+        x = torch.tensor(seqs, dtype=torch.float32)
+        y = torch.tensor(labels, dtype=torch.long)
+        return x, y
+
+    def _train_predictor(self) -> None:
+        data = self._load_training_data()
+        if data == (None, None):
+            return
+        x, y = data  # type: ignore
+        dataset = torch.utils.data.TensorDataset(x, y)
+        loader = torch.utils.data.DataLoader(dataset, batch_size=4, shuffle=True)
+        opt = torch.optim.Adam(self._predictor.parameters(), lr=0.01)
+        loss_fn = nn.CrossEntropyLoss()
+        for _ in range(20):  # pragma: no cover - small training loop
+            for xb, yb in loader:
+                opt.zero_grad()
+                loss = loss_fn(self._predictor(xb), yb)
+                loss.backward()
+                opt.step()
+
+        self._train_x = x
+        self._train_y = y
+
+    def _optimize_parameters(self) -> None:
+        if not hasattr(self, "_train_x"):
+            return
+        pop = [np.random.rand(3) for _ in range(6)]
+        loss_fn = nn.CrossEntropyLoss()
+        for _ in range(5):  # pragma: no cover - short GA loop
+            fitness = []
+            for w in pop:
+                logits = self._predictor(self._train_x) * torch.tensor(w, dtype=torch.float32)
+                loss = loss_fn(logits, self._train_y)
+                fitness.append(-loss.item())
+            ranked = [w for _, w in sorted(zip(fitness, pop), key=lambda t: t[0], reverse=True)]
+            parents = ranked[:2]
+            pop = parents + [np.clip((parents[0] + parents[1]) / 2 + np.random.randn(3) * 0.1, 0, 2) for _ in range(4)]
+        self._selection_weights = ranked[0]
+
+    def predict_best_llm(self) -> str:
+        if len(self._context) < self._seq_len:
+            return "glm"
+        seq = torch.tensor([list(self._context)[-self._seq_len:]], dtype=torch.float32)
+        with torch.no_grad():
+            logits = self._predictor(seq)[0] * torch.tensor(self._selection_weights, dtype=torch.float32)
+            idx = int(torch.argmax(logits))
+        mapping = {0: "glm", 1: "deepseek", 2: "mistral"}
+        return mapping.get(idx, "glm")
+
     def benchmark(self, text: str) -> dict:
         start = perf_counter()
         vec = self.process_inward(text)
@@ -52,6 +145,7 @@ class GateOrchestrator:
         coh = self._coherence(out)
         rel = self._relevance(text, out)
         db_storage.log_benchmark("gate", elapsed, coh, rel, db_path=self._db_path)
+        self._context.append([elapsed, coh, rel, float(len(text))])
         return {
             "vector": vec,
             "out_text": out,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scapy
 soundfile
 requests
 beautifulsoup4
+streamlit

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ sentence-transformers
 transformers>=4.38
 torch>=2.1
 pyopenssl
+streamlit

--- a/tests/test_predictive_gate.py
+++ b/tests/test_predictive_gate.py
@@ -1,0 +1,22 @@
+import importlib
+from pathlib import Path
+
+from inanna_ai import db_storage, gate_orchestrator
+
+
+def test_predictive_model(tmp_path):
+    db = tmp_path / "bench.db"
+    db_storage.init_db(db)
+    models = ["glm", "deepseek", "mistral"]
+    for m in models:
+        db_storage.save_interaction("hello", "neutral", "resp", db_path=db)
+        db_storage.log_benchmark(m, 0.1, 0.9, 0.9, db_path=db)
+    gate = gate_orchestrator.GateOrchestrator(db_path=db)
+    pred = gate.predict_best_llm()
+    assert pred in models
+
+
+def test_dashboard_import():
+    mod = importlib.import_module("dashboard.app")
+    assert mod is not None
+


### PR DESCRIPTION
## Summary
- extend `gate_orchestrator` with an LSTM-based predictor
- apply a simple genetic algorithm to tune selection weights
- add a Streamlit dashboard visualising metrics and predictions
- add regression tests for the predictor and dashboard
- document dashboard usage
- include `streamlit` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_6871237e50bc832ea1dd3b4ddd7d061c