### PR TITLE
Add existential dilemma reflection

### DIFF
--- a/docs/ETHICS_VALIDATION.md
+++ b/docs/ETHICS_VALIDATION.md
@@ -11,3 +11,11 @@ validator = EthicalValidator(banned_categories={"harm": ["cause injury"]}, thres
 ```
 
 If the sentence‑transformers library is unavailable, only keyword checks run.
+
+## Existential Reflection
+
+`ExistentialReflector` offers brief philosophical responses based on the current
+emotion and a short history of prompts. The method `reflect_on_dilemma()`
+packages the user's question, detected emotion and recent context lines into a
+request for the GLM. The returned insight is saved to
+`audit_logs/existential_insights.txt` for transparency.

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "defensive_network_utils",
     "ethical_validator",
     "existential_reflector",
+    "context",
     "personality_layers",
     "learning",
 ]

--- a/inanna_ai/context.py
+++ b/inanna_ai/context.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Lightweight context memory for recent user prompts."""
+
+from collections import deque
+from typing import Deque, List
+
+_MAX_ENTRIES = 5
+_CONTEXT: Deque[str] = deque(maxlen=_MAX_ENTRIES)
+
+
+def add(text: str) -> None:
+    """Add ``text`` to the context memory."""
+    _CONTEXT.append(text)
+
+
+def recent(n: int = 3) -> List[str]:
+    """Return up to ``n`` most recent context entries."""
+    if n <= 0:
+        return []
+    return list(_CONTEXT)[-n:]
+
+
+__all__ = ["add", "recent"]


### PR DESCRIPTION
## Summary
- add lightweight conversation context module
- support context-aware reflection in ExistentialReflector
- test new reflection pathway
- document existential reflection capability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_68712d901c7c832e8a1c65e11ed8e1d1