### PR TITLE
Add feedback logging utilities

### DIFF
--- a/scripts/record_feedback.py
+++ b/scripts/record_feedback.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Log user feedback to the local database."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List, Optional
+
+from inanna_ai import db_storage
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Record feedback metrics")
+    parser.add_argument("emotion", help="Detected emotion")
+    parser.add_argument("satisfaction", type=float, help="Satisfaction score")
+    parser.add_argument("alignment", type=float, help="Ethical alignment score")
+    parser.add_argument("clarity", type=float, help="Existential clarity score")
+    parser.add_argument(
+        "--db", default=str(db_storage.DB_PATH), help="Database path"
+    )
+    args = parser.parse_args(argv)
+
+    db_storage.log_feedback(
+        args.emotion,
+        args.satisfaction,
+        args.alignment,
+        args.clarity,
+        db_path=Path(args.db),
+    )
+    print("Feedback recorded.")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_feedback_logging.py
+++ b/tests/test_feedback_logging.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import db_storage
+
+
+def test_log_and_fetch_feedback(tmp_path):
+    db = tmp_path / "f.db"
+    db_storage.init_db(db)
+    db_storage.log_feedback("calm", 0.8, 0.9, 0.7, db_path=db)
+    db_storage.log_feedback("joy", 1.0, 1.0, 1.0, db_path=db)
+
+    all_rows = db_storage.fetch_feedback(db_path=db)
+    assert len(all_rows) == 2
+    assert all_rows[0]["emotion"] == "joy"
+    assert all_rows[1]["satisfaction"] == 0.8
+
+    limited = db_storage.fetch_feedback(limit=1, db_path=db)
+    assert len(limited) == 1
+    assert limited[0]["emotion"] == "joy"
+


### PR DESCRIPTION
## Summary
- extend `db_storage.py` with a `feedback` table and helper functions
- add a `record_feedback.py` CLI tool
- test feedback logging

## Testing
- `pytest -q` *(fails: 28 errors during collection)*
- `pytest tests/test_feedback_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68713a033f14832ead027d721daac574