### PR TITLE
Add RL metrics dashboard

### DIFF
--- a/dashboard/rl_metrics.py
+++ b/dashboard/rl_metrics.py
@@ -1,0 +1,26 @@
+import streamlit as st
+import pandas as pd
+from inanna_ai import db_storage, adaptive_learning
+
+st.set_page_config(page_title="RL Metrics Dashboard")
+
+st.title("Reinforcement Learning Metrics")
+
+feedback = db_storage.fetch_feedback(limit=100)
+if feedback:
+    df = pd.DataFrame(feedback)
+    st.line_chart(
+        df.set_index("timestamp")[[
+            "satisfaction",
+            "ethical_alignment",
+            "existential_clarity",
+        ]]
+    )
+else:
+    st.write("No feedback data available.")
+
+st.subheader("Validator Threshold")
+st.markdown(
+    f"**Current threshold:** {adaptive_learning.THRESHOLD_AGENT.threshold:.2f}"
+)
+

--- a/docs/ETHICS_VALIDATION.md
+++ b/docs/ETHICS_VALIDATION.md
@@ -19,3 +19,22 @@ emotion and a short history of prompts. The method `reflect_on_dilemma()`
 packages the user's question, detected emotion and recent context lines into a
 request for the GLM. The returned insight is saved to
 `audit_logs/existential_insights.txt` for transparency.
+
+## Reinforcement Learning
+
+User feedback recorded with `db_storage.log_feedback()` provides three reward signals:
+`satisfaction`, `ethical_alignment` and `existential_clarity`. `EthicalValidator.apply_feedback()`
+passes these rewards to `adaptive_learning` which tunes the validator's similarity threshold
+and category lists. The `THRESHOLD_AGENT` adjusts the value after every update so stricter
+rules emerge when alignment scores are low.
+
+A Streamlit dashboard at `dashboard/rl_metrics.py` visualises the latest feedback trends
+and the current threshold. Launch it with:
+
+```bash
+streamlit run dashboard/rl_metrics.py
+```
+
+The line chart plots the reward values over time while the threshold display shows the
+value used by the validator for semantic checks.
+

--- a/tests/test_rl_metrics.py
+++ b/tests/test_rl_metrics.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+import importlib
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import db_storage
+
+
+def test_rl_metrics_module(monkeypatch):
+    class DummyPPO:
+        def __init__(self, *a, **k):
+            pass
+        def learn(self, *a, **k):
+            pass
+    monkeypatch.setitem(sys.modules, "stable_baselines3", types.SimpleNamespace(PPO=DummyPPO))
+    class DummyBox:
+        def __init__(self, *a, **k):
+            pass
+
+    dummy_gym = types.SimpleNamespace(
+        Env=type("Env", (), {}),
+        spaces=types.SimpleNamespace(Box=DummyBox),
+    )
+    monkeypatch.setitem(sys.modules, "gymnasium", dummy_gym)
+
+    dummy_streamlit = types.SimpleNamespace(
+        set_page_config=lambda **k: None,
+        title=lambda x: None,
+        line_chart=lambda x: None,
+        write=lambda x: None,
+        subheader=lambda x: None,
+        markdown=lambda x: None,
+    )
+    monkeypatch.setitem(sys.modules, "streamlit", dummy_streamlit)
+
+    monkeypatch.setattr(
+        db_storage,
+        "fetch_feedback",
+        lambda limit=None: [
+            {
+                "timestamp": "2024-01-01T00:00:00",
+                "emotion": "calm",
+                "satisfaction": 0.9,
+                "ethical_alignment": 0.8,
+                "existential_clarity": 1.0,
+            }
+        ],
+    )
+
+    mod = importlib.import_module("dashboard.rl_metrics")
+    assert mod is not None
+


### PR DESCRIPTION
## Summary
- visualize reward feedback trends and threshold in a new Streamlit dashboard
- document RL updates and dashboard usage in ETHICS_VALIDATION
- add regression test for rl_metrics dashboard

## Testing
- `pytest tests/test_rl_metrics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68713b64f784832e94167fd342a69898