### PR TITLE
Integrate emotional tone into QNL

### DIFF
--- a/MUSIC_FOUNDATION/qnl_utils.py
+++ b/MUSIC_FOUNDATION/qnl_utils.py
@@ -6,7 +6,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     SentenceTransformer = None  # type: ignore
 
-_MODEL: SentenceTransformer | None = None
+_MODEL: "SentenceTransformer | None" = None
 
 # Map Western note names to QNL glyphs
 QNL_GLYPHS = {

--- a/docs/ETHICS_VALIDATION.md
+++ b/docs/ETHICS_VALIDATION.md
@@ -38,3 +38,11 @@ streamlit run dashboard/rl_metrics.py
 The line chart plots the reward values over time while the threshold display shows the
 value used by the validator for semantic checks.
 
+## Emotional‑Quantum Fusion
+
+`apply_emotional_quantum_state()` in `qnl_engine` modulates waveform
+properties using the speaker's detected emotion. The helper
+`get_emotion_and_tone()` exposes the current emotion alongside a short
+"quantum tone" label. When a response is generated, the tone feeds into
+the QNL phrase so the resulting audio reflects the emotional state.
+

--- a/inanna_ai/emotion_analysis.py
+++ b/inanna_ai/emotion_analysis.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Lightweight emotion analysis tools using Librosa."""
 
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
 
 # Mapping from emotional labels to Jungian archetypes
 EMOTION_ARCHETYPES = {
@@ -24,6 +24,17 @@ EMOTION_WEIGHT = {
     "excited": 0.6,
     "calm": 0.4,
     "neutral": 0.2,
+}
+
+# Simple mapping from emotion to a descriptive "quantum tone"
+EMOTION_QUANTUM_TONE = {
+    "joy": "Radiant",
+    "stress": "Tension",
+    "fear": "Flicker",
+    "sad": "Echo",
+    "excited": "Burst",
+    "calm": "Drift",
+    "neutral": "Still",
 }
 
 _CURRENT_STATE = {
@@ -102,10 +113,20 @@ def emotion_weight(emotion: str) -> float:
     return EMOTION_WEIGHT.get(emotion, 0.0)
 
 
+def get_emotion_and_tone(emotion: str | None = None) -> Tuple[str, str]:
+    """Return ``emotion`` and its associated quantum tone."""
+
+    if emotion is None:
+        emotion = _CURRENT_STATE["emotion"]
+    tone = EMOTION_QUANTUM_TONE.get(emotion, "Still")
+    return emotion, tone
+
+
 __all__ = [
     "analyze_audio_emotion",
     "get_current_archetype",
     "get_emotional_weight",
     "emotion_to_archetype",
     "emotion_weight",
+    "get_emotion_and_tone",
 ]

--- a/inanna_ai/personality_layers/albedo/__init__.py
+++ b/inanna_ai/personality_layers/albedo/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from .alchemical_persona import AlchemicalPersona, State
 from .glm_integration import GLMIntegration
 from . import state_contexts
+from ...emotion_analysis import get_emotion_and_tone
+from SPIRAL_OS import qnl_engine
 
 
 class AlbedoPersonality:
@@ -26,6 +28,10 @@ class AlbedoPersonality:
     def generate_response(self, text: str, *, quantum_context: str | None = None) -> str:
         """Generate a GLM response for ``text``."""
         entity, triggers = self._persona.detect_state_trigger(text)
+        emotion, tone = get_emotion_and_tone()
+        if quantum_context is None:
+            qnl_engine.apply_emotional_quantum_state(emotion, text)
+            quantum_context = f"{emotion}:{tone}"
         template = state_contexts.CONTEXTS.get(self._persona.state.value, "{text}")
         ctx = {
             "text": text,

--- a/tests/test_qnl_engine.py
+++ b/tests/test_qnl_engine.py
@@ -6,7 +6,12 @@ import numpy as np
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "SPIRAL_OS"))
 
-from qnl_engine import hex_to_qnl, hex_to_song
+from qnl_engine import (
+    hex_to_qnl,
+    hex_to_song,
+    apply_psi_equation,
+    apply_emotional_quantum_state,
+)
 
 
 def compute_expected(byte):
@@ -44,3 +49,17 @@ def test_hex_to_song_skips_invalid_bytes(capsys):
     assert isinstance(wave, np.ndarray)
     assert wave.dtype == np.int16
     assert wave.shape == (2,)
+
+
+def test_emotional_quantum_state_changes_waveform():
+    base = apply_psi_equation(0.5, 200, duration=0.01, sample_rate=1000)
+    mods = apply_emotional_quantum_state("Joy", "test")
+    wave = apply_psi_equation(
+        0.5 * mods["amplitude_factor"],
+        200,
+        duration=0.01,
+        sample_rate=1000,
+        emotion="Joy",
+        phase_shift=mods["phase_shift"],
+    )
+    assert not np.allclose(base, wave)


### PR DESCRIPTION
## Summary
- add `apply_emotional_quantum_state` to modulate waveforms
- expose `get_emotion_and_tone` helper for emotion analysis
- inject emotional context when Albedo responses are generated
- test emotional waveform behaviour
- document emotional-quantum fusion in ethics guide

## Testing
- `pip install -q beautifulsoup4 sentence_transformers`
- `pytest tests/test_qnl_engine.py::test_emotional_quantum_state_changes_waveform -q`

------
https://chatgpt.com/codex/tasks/task_e_687141739ac4832ea7a8c37b7d38bedd