### PR TITLE
Add QNL text mixer and dashboard

### DIFF
--- a/SPIRAL_OS/README_QNL_OS.md
+++ b/SPIRAL_OS/README_QNL_OS.md
@@ -50,7 +50,24 @@ The options `--wav` and `--json` let you choose the filenames. Without them, the
 }
 ```
 
+## 🎛 Real-time QNL Mixer
+
+Use `mix_tracks.py` with `--qnl-text` to adjust pitch, tempo and filtering based on QNL embeddings.
+
+```bash
+python SPIRAL_OS/mix_tracks.py drum.wav bass.wav \
+    --qnl-text "open the inner gate" --output final.wav
+```
+
+Start the Streamlit dashboard for interactive control:
+
+```bash
+streamlit run dashboard/qnl_mixer.py
+```
+
+Upload a WAV file, type QNL text and watch the spectrogram update.
 ---
+
 
 ## 💠 About
 
@@ -64,3 +81,4 @@ The options `--wav` and `--json` let you choose the filenames. Without them, the
 
 ZOHAR ∴ Spiral Architect of QNL Mythos
 Maintained under the eternal whisper of `ψ̄ᴸ ∶ SPIRAL-SELF(∞)`
+

--- a/SPIRAL_OS/mix_tracks.py
+++ b/SPIRAL_OS/mix_tracks.py
@@ -12,9 +12,13 @@ import argparse
 import os
 from typing import Iterable, List
 
+from scipy.signal import butter, lfilter
+
 import librosa
 import numpy as np
 import soundfile as sf
+
+from MUSIC_FOUNDATION.qnl_utils import quantum_embed
 
 
 def load_audio(path: str, sample_rate: int = 44100) -> np.ndarray:
@@ -58,6 +62,40 @@ def create_preview(
     export_wav(preview, path, sample_rate=sample_rate)
 
 
+def embedding_to_params(embedding: np.ndarray) -> tuple[float, float, float]:
+    """Return pitch, tempo and cutoff values mapped from ``embedding``."""
+    if embedding.size == 0:
+        return 0.0, 1.0, 1.0
+    emb = embedding.astype(np.float32)
+    max_abs = np.max(np.abs(emb)) or 1.0
+    emb = emb / max_abs
+    pitch = float(emb[0]) * 2.0  # +/-2 semitones
+    tempo = 1.0 + float(emb[1]) * 0.1  # ~0.9 - 1.1
+    cutoff = 0.5 + float(emb[2]) * 0.5  # 0.0 - 1.0 * Nyquist
+    return pitch, tempo, cutoff
+
+
+def apply_audio_params(
+    wave: np.ndarray,
+    sample_rate: int,
+    pitch: float,
+    tempo: float,
+    cutoff: float,
+) -> np.ndarray:
+    """Apply pitch, tempo and low-pass filter adjustments."""
+    out = wave
+    if pitch:
+        out = librosa.effects.pitch_shift(out, sr=sample_rate, n_steps=pitch)
+    if tempo != 1.0:
+        out = librosa.effects.time_stretch(out, rate=tempo)
+    if cutoff < 1.0:
+        nyq = 0.5 * sample_rate
+        freq = max(min(cutoff * nyq, nyq - 1.0), 20.0) / nyq
+        b, a = butter(4, freq, btype="low")
+        out = lfilter(b, a, out)
+    return out
+
+
 def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Mix audio files")
     parser.add_argument("files", nargs="+", help="Input audio files")
@@ -69,10 +107,20 @@ def main(argv: List[str] | None = None) -> None:
         default=5.0,
         help="Preview length in seconds",
     )
+    parser.add_argument(
+        "--qnl-text",
+        help="Text to analyse with quantum embedding for live mixing",
+    )
     args = parser.parse_args(argv)
 
     waves = [load_audio(f) for f in args.files]
     mixed = mix_waveforms(waves)
+
+    if args.qnl_text:
+        emb = quantum_embed(args.qnl_text)
+        pitch, tempo, cutoff = embedding_to_params(emb)
+        mixed = apply_audio_params(mixed, 44100, pitch, tempo, cutoff)
+
     export_wav(mixed, args.output)
 
     if args.preview:
@@ -85,3 +133,4 @@ def main(argv: List[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/dashboard/qnl_mixer.py
+++ b/dashboard/qnl_mixer.py
@@ -1,0 +1,36 @@
+import io
+
+import librosa
+import librosa.display
+import matplotlib.pyplot as plt
+import numpy as np
+import soundfile as sf
+import streamlit as st
+
+from MUSIC_FOUNDATION.qnl_utils import quantum_embed
+from SPIRAL_OS.mix_tracks import apply_audio_params, embedding_to_params
+
+st.set_page_config(page_title="QNL Mixer")
+
+st.title("Real-time QNL Mixer")
+
+uploaded = st.file_uploader("Upload WAV", type=["wav"])
+text = st.text_input("QNL text", "")
+
+if uploaded is not None:
+    data, sr = librosa.load(uploaded, sr=44100, mono=True)
+    if text:
+        emb = quantum_embed(text)
+        pitch, tempo, cutoff = embedding_to_params(emb)
+        data = apply_audio_params(data, sr, pitch, tempo, cutoff)
+    spec = np.abs(librosa.stft(data))
+    db = librosa.amplitude_to_db(spec, ref=np.max)
+    fig, ax = plt.subplots()
+    img = librosa.display.specshow(db, sr=sr, x_axis="time", y_axis="log", ax=ax)
+    ax.set(title="Spectrogram")
+    fig.colorbar(img, ax=ax, format="%+2.f dB")
+    st.pyplot(fig)
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV")
+    st.audio(buf.getvalue(), format="audio/wav")
+

--- a/tests/test_mix_tracks.py
+++ b/tests/test_mix_tracks.py
@@ -44,3 +44,34 @@ def test_mix_tracks_cli(tmp_path):
     info = sf.info(out)
     assert info.samplerate == 44100
     assert info.subtype.startswith("PCM_16")
+
+
+def test_mix_tracks_with_qnl_text(tmp_path, monkeypatch):
+    sr = 44100
+    t = np.linspace(0, 0.25, sr // 4, endpoint=False)
+    tone = 0.5 * np.sin(2 * np.pi * 220 * t)
+    wav = tmp_path / "tone.wav"
+    sf.write(wav, tone, sr)
+
+    out = tmp_path / "final.wav"
+
+    from SPIRAL_OS import mix_tracks as mt
+
+    monkeypatch.setattr(mt, "quantum_embed", lambda text: np.array([0.5, -0.5, 0]))
+
+    argv_backup = sys.argv.copy()
+    sys.argv = [
+        "mix_tracks.py",
+        str(wav),
+        "--output",
+        str(out),
+        "--qnl-text",
+        "test words",
+    ]
+    try:
+        mt.main()
+    finally:
+        sys.argv = argv_backup
+
+    assert out.exists()
+


### PR DESCRIPTION
## Summary
- update mix_tracks CLI with `--qnl-text` option
- map quantum embeddings to pitch, tempo and filter
- add Streamlit dashboard for real-time mixing
- document QNL mixer usage
- test new CLI option

## Testing
- `pytest tests/test_mix_tracks.py::test_mix_tracks_cli tests/test_mix_tracks.py::test_mix_tracks_with_qnl_text -q`

------
https://chatgpt.com/codex/tasks/task_e_68714596bb3c832ebc6c4ca41ea726d6