### PR TITLE
Add quantum adaptive music generation

### DIFF
--- a/SEVEN_DIMENSIONAL_MUSIC.md
+++ b/SEVEN_DIMENSIONAL_MUSIC.md
@@ -28,6 +28,15 @@ python SPIRAL_OS/seven_dimensional_music.py --melody sample.mid --message "Greet
 
 The script writes `human_layer.wav`, `crystal_layer.wav`, `synthetic_layer.wav`, and a mixed `final_track.wav` with `final_track.json` describing the seven‑plane analysis.
 
+## Quantum Adaptation
+
+`generate_quantum_music(context, emotion)` embeds the textual context and
+emotion using `quantum_embed`. The resulting vector maps to pitch, tempo and
+filter values that alter each layer. When `reactive_music_loop` calls
+`emotion_analysis` on a stream of audio, a new track is generated whenever the
+detected emotion changes. This produces music that evolves with the listener's
+mood.
+
 ## Decoding the Synthetic Layer
 
 The secret text is embedded in `human_layer.wav`. You can decode it using `synthetic_stego.extract_data`:


### PR DESCRIPTION
## Summary
- extend seven_dimensional music layers with pitch/tempo controls
- add `generate_quantum_music` and `reactive_music_loop`
- test quantum music generation for different contexts
- document quantum adaptation process

## Testing
- `pytest tests/test_seven_dimensional_music.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687147ede490832ebf01ada761b5e9f1