### PR TITLE
Enhance emotion analysis and adaptive voice

### DIFF
--- a/inanna_ai/voice_evolution.py
+++ b/inanna_ai/voice_evolution.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 
+import numpy as np
+
 DEFAULT_VOICE_STYLES: Dict[str, Dict[str, float]] = {
     "neutral": {"speed": 1.0, "pitch": 0.0},
     "calm": {"speed": 0.9, "pitch": -1.0},
@@ -23,8 +25,24 @@ class VoiceEvolution:
         return self.styles.get(emotion.lower(), self.styles["neutral"])
 
     def update_from_history(self, history: Iterable[Dict[str, Any]]) -> None:
-        """Placeholder for future style adaptation logic."""
-        _ = history
+        """Adjust voice styles based on recent emotion analyses."""
+        grouped: Dict[str, Dict[str, list[float]]] = {}
+        for entry in history:
+            emotion = entry.get("emotion")
+            if emotion is None:
+                continue
+            if "arousal" not in entry or "valence" not in entry:
+                continue
+            data = grouped.setdefault(emotion, {"arousal": [], "valence": []})
+            data["arousal"].append(entry["arousal"])
+            data["valence"].append(entry["valence"])
+
+        for emotion, values in grouped.items():
+            arousal = float(np.mean(values["arousal"]))
+            valence = float(np.mean(values["valence"]))
+            style = self.styles.setdefault(emotion, {"speed": 1.0, "pitch": 0.0})
+            style["speed"] = round(1.0 + (arousal - 0.5) * 0.4, 3)
+            style["pitch"] = round((valence - 0.5) * 2.0, 3)
 
     def reset(self) -> None:
         """Reset styles to the default values."""
@@ -39,4 +57,14 @@ def get_voice_params(emotion: str) -> Dict[str, float]:
     return _evolver.get_params(emotion)
 
 
-__all__ = ["VoiceEvolution", "get_voice_params", "DEFAULT_VOICE_STYLES"]
+def update_voice_from_history(history: Iterable[Dict[str, Any]]) -> None:
+    """Update the default :class:`VoiceEvolution` with ``history``."""
+    _evolver.update_from_history(history)
+
+
+__all__ = [
+    "VoiceEvolution",
+    "get_voice_params",
+    "update_voice_from_history",
+    "DEFAULT_VOICE_STYLES",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ accelerate
 einops
 scapy
 soundfile
+opensmile
 requests
 beautifulsoup4
 streamlit

--- a/tests/test_audio_tools.py
+++ b/tests/test_audio_tools.py
@@ -5,7 +5,7 @@ import base64
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from inanna_ai import stt_whisper, emotion_analysis
+from inanna_ai import stt_whisper, emotion_analysis, voice_evolution
 from inanna_ai.listening_engine import _extract_features
 from tests.data.test1_wav_base64 import TEST1_WAV_BASE64
 
@@ -37,7 +37,7 @@ def test_transcribe_audio(tmp_path, monkeypatch):
 def test_analyze_audio_emotion(tmp_path):
     audio_path = _write_audio(tmp_path)
     info = emotion_analysis.analyze_audio_emotion(str(audio_path))
-    assert set(info) == {"emotion", "pitch", "tempo"}
+    assert set(info) == {"emotion", "pitch", "tempo", "arousal", "valence"}
     # helper functions should expose archetype and weight
     arch = emotion_analysis.get_current_archetype()
     weight = emotion_analysis.get_emotional_weight()
@@ -87,3 +87,14 @@ def test_emotion_archetype_mapping(tmp_path):
     info = emotion_analysis.analyze_audio_emotion(str(sad_path))
     assert info["emotion"] == "sad"
     assert emotion_analysis.get_current_archetype() == "Caregiver"
+
+
+def test_voice_evolution_updates_from_emotion(tmp_path):
+    path = _save_sine(tmp_path, 440.0, 0.8)
+    info = emotion_analysis.analyze_audio_emotion(str(path))
+    voice_evolution.update_voice_from_history([info])
+    params = voice_evolution.get_voice_params(info["emotion"])
+    expected_speed = round(1.0 + (info["arousal"] - 0.5) * 0.4, 3)
+    expected_pitch = round((info["valence"] - 0.5) * 2.0, 3)
+    assert params["speed"] == expected_speed
+    assert params["pitch"] == expected_pitch


### PR DESCRIPTION
## Summary
- integrate openSMILE to compute arousal/valence vectors
- adapt voice evolution from recent emotion history
- allow speech synthesis to update voice parameters
- extend tests for new emotion vectors and voice adaptation
- add opensmile to requirements

## Testing
- `pytest tests/test_audio_tools.py::test_analyze_audio_emotion -q`
- `pytest tests/test_audio_tools.py::test_voice_evolution_updates_from_emotion -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*

------
https://chatgpt.com/codex/tasks/task_e_687157b3f254832e871dbe309137270b