### PR TITLE
Implement adaptive voice style storage

### DIFF
--- a/inanna_ai/README.md
+++ b/inanna_ai/README.md
@@ -63,6 +63,14 @@ The feature dictionary returned by the listening engine now also contains a
 `dialect` label inferred from pitch and a numeric `weight` taken from
 `emotion_analysis.EMOTION_WEIGHT`.
 
+## Adaptive voice loop
+
+`voice_evolution.VoiceEvolution` stores style parameters for each emotion in a
+SQLite table.  When speech is synthesized the engine appends a sentiment score
+for the text and updates these profiles.  The new parameters are averaged with
+previous values so the voice slowly adapts to positive or negative feedback.
+Profiles are written back to the database via `db_storage.save_voice_profiles`.
+
 The `response_manager.ResponseManager` pairs this emotional state and the
 environment classification with your transcript. It queries the corpus memory
 for related snippets and returns a reply tagged with one of the four cores

--- a/inanna_ai/speaking_engine.py
+++ b/inanna_ai/speaking_engine.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, Tuple
 import numpy as np
 import librosa
 
-from .utils import save_wav, load_audio
+from .utils import save_wav, load_audio, sentiment_score
 from .voice_evolution import get_voice_params, update_voice_from_history
 from .emotion_analysis import emotion_to_archetype
 
@@ -72,8 +72,16 @@ def synthesize_speech(
     timbre: str = "neutral",
 ) -> str:
     """Synthesize ``text`` to a WAV file styled by ``emotion``."""
-    if history:
-        update_voice_from_history(history)
+    entries = list(history) if history else []
+    entries.append(
+        {
+            "emotion": emotion,
+            "arousal": 0.5,
+            "valence": 0.5,
+            "sentiment": sentiment_score(text),
+        }
+    )
+    update_voice_from_history(entries)
     style = get_voice_params(emotion)
     archetype = emotion_to_archetype(emotion)
     out_path = Path(tempfile.gettempdir()) / f"gtts_{abs(hash(text))}.wav"

--- a/inanna_ai/utils.py
+++ b/inanna_ai/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Tuple
+import re
 
 import librosa
 import numpy as np
@@ -29,3 +30,26 @@ def save_wav(wave: np.ndarray, path: str, sr: int = 44100) -> None:
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     sf.write(path, wave, sr, subtype="PCM_16")
     logger.info("Saved WAV to %s", path)
+
+
+SENTIMENT_LEXICON = {
+    "good": 1.0,
+    "love": 1.0,
+    "great": 1.0,
+    "happy": 0.5,
+    "nice": 0.5,
+    "bad": -1.0,
+    "hate": -1.0,
+    "awful": -1.0,
+    "sad": -0.5,
+    "terrible": -1.0,
+}
+
+
+def sentiment_score(text: str) -> float:
+    """Return a crude sentiment score between -1 and 1 for ``text``."""
+    tokens = re.findall(r"\w+", text.lower())
+    if not tokens:
+        return 0.0
+    score = sum(SENTIMENT_LEXICON.get(tok, 0.0) for tok in tokens)
+    return float(np.clip(score / len(tokens), -1.0, 1.0))

--- a/tests/test_audio_tools.py
+++ b/tests/test_audio_tools.py
@@ -5,7 +5,7 @@ import base64
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from inanna_ai import stt_whisper, emotion_analysis, voice_evolution
+from inanna_ai import stt_whisper, emotion_analysis, voice_evolution, utils
 from inanna_ai.listening_engine import _extract_features
 from tests.data.test1_wav_base64 import TEST1_WAV_BASE64
 
@@ -92,9 +92,16 @@ def test_emotion_archetype_mapping(tmp_path):
 def test_voice_evolution_updates_from_emotion(tmp_path):
     path = _save_sine(tmp_path, 440.0, 0.8)
     info = emotion_analysis.analyze_audio_emotion(str(path))
+    info["sentiment"] = utils.sentiment_score("good")
     voice_evolution.update_voice_from_history([info])
     params = voice_evolution.get_voice_params(info["emotion"])
     expected_speed = round(1.0 + (info["arousal"] - 0.5) * 0.4, 3)
     expected_pitch = round((info["valence"] - 0.5) * 2.0, 3)
-    assert params["speed"] == expected_speed
-    assert params["pitch"] == expected_pitch
+    weight = 1.0 + info["sentiment"]
+    start = voice_evolution.DEFAULT_VOICE_STYLES.get(
+        info["emotion"], voice_evolution.DEFAULT_VOICE_STYLES["neutral"]
+    )
+    exp_speed = round((start["speed"] + expected_speed * weight) / (1.0 + weight), 3)
+    exp_pitch = round((start["pitch"] + expected_pitch * weight) / (1.0 + weight), 3)
+    assert params["speed"] == exp_speed
+    assert params["pitch"] == exp_pitch

--- a/tests/test_voice_profiles.py
+++ b/tests/test_voice_profiles.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import db_storage, voice_evolution, utils
+
+
+def test_voice_profile_storage(tmp_path):
+    db = tmp_path / "voice.db"
+    db_storage.init_db(db)
+    profile = {"joy": {"speed": 1.2, "pitch": 0.3}}
+    db_storage.save_voice_profiles(profile, db_path=db)
+    out = db_storage.fetch_voice_profiles(db_path=db)
+    assert out == profile
+
+
+def test_update_with_sentiment():
+    evol = voice_evolution.VoiceEvolution({"joy": {"speed": 1.0, "pitch": 0.0}})
+    score = utils.sentiment_score("I love this good day")
+    history = [{"emotion": "joy", "arousal": 0.6, "valence": 0.8, "sentiment": score}]
+    evol.update_from_history(history)
+    new_speed = round(1.0 + (0.6 - 0.5) * 0.4, 3)
+    new_pitch = round((0.8 - 0.5) * 2.0, 3)
+    weight = 1.0 + score
+    expected_speed = round((1.0 + new_speed * weight) / (1.0 + weight), 3)
+    expected_pitch = round((0.0 + new_pitch * weight) / (1.0 + weight), 3)
+    assert evol.styles["joy"]["speed"] == expected_speed
+    assert evol.styles["joy"]["pitch"] == expected_pitch
+
+
+def test_store_and_load_profiles(tmp_path):
+    db = tmp_path / "v.db"
+    db_storage.init_db(db)
+    evol = voice_evolution.VoiceEvolution()
+    evol.styles["calm"]["speed"] = 0.8
+    evol.store_profiles(db)
+    other = voice_evolution.VoiceEvolution()
+    other.load_profiles(db)
+    assert other.styles["calm"]["speed"] == 0.8
+


### PR DESCRIPTION
## Summary
- extend `db_storage` with voice profile persistence
- integrate sentiment feedback and persistence in `voice_evolution`
- update `SpeakingEngine` to feed sentiment into style updates
- expose `sentiment_score` utility and document adaptive loop
- adjust audio tools test and add new tests for profiles

## Testing
- `pytest tests/test_voice_profiles.py tests/test_audio_tools.py::test_voice_evolution_updates_from_emotion -q`

------
https://chatgpt.com/codex/tasks/task_e_68715de8a654832e945894a526d19de5