### PR TITLE
Add VoiceEvolution and SpeakingEngine tests

### DIFF
--- a/tests/test_speaking_engine.py
+++ b/tests/test_speaking_engine.py
@@ -1,9 +1,14 @@
 import sys
+import types
 from pathlib import Path
 import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+# provide lightweight stubs for heavy optional modules
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
 
 from inanna_ai import speaking_engine
 
@@ -44,3 +49,33 @@ def test_play_wav(monkeypatch):
     assert played["loaded"] == "x.wav"
     assert played["sr"] == 22050
     assert played["waited"]
+
+
+def test_emotion_modifies_style(tmp_path, monkeypatch):
+    """Voice parameters from emotion should be applied when synthesizing."""
+
+    style = {"speed": 1.2, "pitch": 0.5}
+    captured = {}
+
+    class DummyTTS:
+        def __init__(self, text):
+            self.text = text
+
+        def save(self, path):
+            Path(path).write_bytes(b"dummy")
+
+    def dummy_apply(wave, sr, params):
+        captured["params"] = params
+        return wave
+
+    monkeypatch.setattr(speaking_engine, "gTTS", DummyTTS)
+    monkeypatch.setattr(speaking_engine, "emotion_to_archetype", lambda e: "Sage")
+    monkeypatch.setattr(speaking_engine, "get_voice_params", lambda e: style)
+    monkeypatch.setattr(speaking_engine, "_apply_style", dummy_apply)
+    monkeypatch.setattr(speaking_engine, "convert_voice", lambda w, sr, timbre: w)
+    monkeypatch.setattr(speaking_engine.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(speaking_engine.librosa, "load", lambda *a, **k: (np.zeros(22050), 22050))
+
+    path = speaking_engine.synthesize_speech("hi", "joy")
+    assert Path(path).exists()
+    assert captured["params"] == style

--- a/tests/test_voice_evolution.py
+++ b/tests/test_voice_evolution.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import voice_evolution
+
+
+def test_update_from_history_modifies_style():
+    evol = voice_evolution.VoiceEvolution({'joy': {'speed': 1.0, 'pitch': 0.0}})
+    history = [
+        {'emotion': 'joy', 'arousal': 0.7, 'valence': 0.8, 'sentiment': 0.2},
+        {'emotion': 'joy', 'arousal': 0.8, 'valence': 0.6, 'sentiment': 0.4},
+    ]
+    evol.update_from_history(history)
+    arousal = float(np.mean([0.7, 0.8]))
+    valence = float(np.mean([0.8, 0.6]))
+    sentiment = float(np.mean([0.2, 0.4]))
+    new_speed = round(1.0 + (arousal - 0.5) * 0.4, 3)
+    new_pitch = round((valence - 0.5) * 2.0, 3)
+    weight = 1.0 + sentiment
+    exp_speed = round((1.0 + new_speed * weight) / (1.0 + weight), 3)
+    exp_pitch = round((0.0 + new_pitch * weight) / (1.0 + weight), 3)
+    assert evol.styles['joy']['speed'] == exp_speed
+    assert evol.styles['joy']['pitch'] == exp_pitch
+
+
+def test_get_params_returns_default_for_unknown():
+    evol = voice_evolution.VoiceEvolution()
+    params = evol.get_params('unknown')
+    assert params == evol.styles['neutral']


### PR DESCRIPTION
## Summary
- add voice_evolution tests for style updates and default retrieval
- mock heavy modules in speaking engine tests and validate style usage when synthesizing speech

## Testing
- `pytest tests/test_voice_evolution.py tests/test_speaking_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687162749710832e8fefb5f564d17c41