### PR TITLE
Add scheduled data refresh workflow

### DIFF
--- a/.github/workflows/data_refresh.yml
+++ b/.github/workflows/data_refresh.yml
@@ -1,0 +1,33 @@
+name: Data refresh
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Update GitHub repository list
+        run: python -m inanna_ai.main update-github-list --metadata
+      - name: Fetch GitHub repositories
+        run: python -m inanna_ai.main fetch-github
+      - name: Ingest Project Gutenberg text
+        run: |
+          python - <<'PY'
+          from inanna_ai.learning import project_gutenberg as pg
+          pg.ingest("Frankenstein")
+          PY
+      - name: Reindex corpus memory
+        run: python -m inanna_ai.corpus_memory --reindex


### PR DESCRIPTION
## Summary
- add `data_refresh.yml` GitHub Actions workflow

## Testing
- `pytest -q tests/test_github_scraper.py::test_fetch_all_uses_repo_list tests/test_project_gutenberg.py::test_chunk_respects_token_limit`

------
https://chatgpt.com/codex/tasks/task_e_6871712b154c832e932d13051f610d80