### PR TITLE
Implement retraining pipeline

### DIFF
--- a/.github/workflows/retraining_pipeline.yml
+++ b/.github/workflows/retraining_pipeline.yml
@@ -1,0 +1,25 @@
+name: Retraining pipeline
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_run:
+    workflows: ["Data refresh"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  retrain:
+    runs-on: ubuntu-latest
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Retrain and deploy
+        run: python -m inanna_ai.retrain_and_deploy

--- a/inanna_ai/__init__.py
+++ b/inanna_ai/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "rfa_7d",
     "gate_orchestrator",
     "train_soul",
+    "retrain_and_deploy",
     "network_utils",
     "defensive_network_utils",
     "ethical_validator",

--- a/inanna_ai/retrain_and_deploy.py
+++ b/inanna_ai/retrain_and_deploy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Automate fine-tuning and deployment of INANNA models."""
+
+from datetime import datetime
+from pathlib import Path
+import os
+import shutil
+import argparse
+
+from . import train_soul
+from .corpus_memory import CHROMA_DIR
+from . import config
+
+import mlflow
+
+# Location of versioned soul artifacts and metadata
+SOUL_DIR = config.MODELS_DIR / "soul"
+SOUL_DIR.mkdir(parents=True, exist_ok=True)
+LAST_TRAIN_FILE = SOUL_DIR / "last_trained.txt"
+SOUL_FILE = Path(__file__).resolve().parents[1] / "INANNA_AI" / "soul.dna"
+
+
+def _latest_mod_time(path: Path) -> float:
+    latest = 0.0
+    if path.exists():
+        for root, _dirs, files in os.walk(path):
+            for name in files:
+                t = (Path(root) / name).stat().st_mtime
+                if t > latest:
+                    latest = t
+    return latest
+
+
+def has_new_embeddings() -> bool:
+    """Return ``True`` if ``CHROMA_DIR`` contains files newer than last run."""
+    if not LAST_TRAIN_FILE.exists():
+        return True
+    last = datetime.fromisoformat(LAST_TRAIN_FILE.read_text().strip())
+    return _latest_mod_time(CHROMA_DIR) > last.timestamp()
+
+
+def _record_timestamp() -> None:
+    LAST_TRAIN_FILE.write_text(datetime.utcnow().isoformat())
+
+
+def retrain_and_deploy(iterations: int = 3) -> None:
+    """Fine-tune the soul grid if new embeddings exist and log with MLflow."""
+    if not has_new_embeddings():
+        print("No new embeddings detected")
+        return
+
+    mlflow.start_run()
+    mlflow.log_param("iterations", iterations)
+    train_soul.train_soul(Path("QNL_LANGUAGE/interactions/log.txt"), iterations)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_dir = SOUL_DIR / timestamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifact = out_dir / "soul.dna"
+    shutil.copy(SOUL_FILE, artifact)
+    mlflow.log_artifact(str(artifact))
+    mlflow.end_run()
+
+    _record_timestamp()
+
+
+def rollback(version: str) -> None:
+    """Restore ``soul.dna`` from ``version`` under ``SOUL_DIR``."""
+    src = SOUL_DIR / version / "soul.dna"
+    if not src.exists():
+        raise FileNotFoundError(f"version {version} not found")
+    shutil.copy(src, SOUL_FILE)
+    _record_timestamp()
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Retrain INANNA models")
+    parser.add_argument("--iterations", type=int, default=3, help="Training steps")
+    parser.add_argument("--rollback", help="Rollback to previous version")
+    args = parser.parse_args(argv)
+
+    if args.rollback:
+        rollback(args.rollback)
+    else:
+        retrain_and_deploy(args.iterations)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ streamlit
 sentence-transformers  # optional, for semantic validation
 stable-baselines3
 chromadb
+mlflow

--- a/tests/test_retrain_and_deploy.py
+++ b/tests/test_retrain_and_deploy.py
@@ -1,0 +1,98 @@
+import sys
+from types import SimpleNamespace, ModuleType
+from datetime import datetime, timedelta
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Provide dummy cryptography modules to satisfy imports
+crypto = ModuleType("cryptography")
+hazmat = ModuleType("cryptography.hazmat")
+primitives = ModuleType("cryptography.hazmat.primitives")
+hashes = ModuleType("hashes")
+hashes.SHA256 = object
+primitives.hashes = hashes
+asym = ModuleType("cryptography.hazmat.primitives.asymmetric")
+pad = ModuleType("pad")
+pad.PKCS1v15 = object
+rsa_mod = ModuleType("rsa")
+rsa_mod.generate_private_key = lambda *a, **k: None
+ser = ModuleType("ser")
+ser.load_pem_private_key = lambda *a, **k: SimpleNamespace(sign=lambda *a, **k: b"", public_key=lambda: None)
+ser.load_pem_public_key = lambda *a, **k: SimpleNamespace(verify=lambda *a, **k: None)
+ser.Encoding = ser.PrivateFormat = ser.PublicFormat = ser.NoEncryption = object
+sys.modules.update({
+    "cryptography": crypto,
+    "cryptography.hazmat": hazmat,
+    "cryptography.hazmat.primitives": primitives,
+    "cryptography.hazmat.primitives.asymmetric": asym,
+    "cryptography.hazmat.primitives.asymmetric.padding": pad,
+    "cryptography.hazmat.primitives.asymmetric.rsa": rsa_mod,
+    "cryptography.hazmat.primitives.serialization": ser,
+})
+
+mlflow_dummy = SimpleNamespace(
+    start_run=lambda: None,
+    log_param=lambda *a, **k: None,
+    log_artifact=lambda *a, **k: None,
+    end_run=lambda: None,
+)
+sys.modules["mlflow"] = mlflow_dummy
+
+from inanna_ai import retrain_and_deploy
+from inanna_ai import train_soul
+
+
+def _prepare(tmp_path, monkeypatch):
+    model_dir = tmp_path / "models"
+    soul_dir = model_dir / "soul"
+    soul_dir.mkdir(parents=True)
+    chroma_dir = tmp_path / "chroma"
+    chroma_dir.mkdir()
+    (chroma_dir / "emb").write_text("x")
+
+    dummy_soul = tmp_path / "soul.dna"
+    dummy_soul.write_text("dna")
+
+    monkeypatch.setattr(retrain_and_deploy, "CHROMA_DIR", chroma_dir)
+    monkeypatch.setattr(retrain_and_deploy.config, "MODELS_DIR", model_dir)
+    monkeypatch.setattr(retrain_and_deploy, "SOUL_DIR", soul_dir)
+    monkeypatch.setattr(retrain_and_deploy, "SOUL_FILE", dummy_soul)
+    monkeypatch.setattr(retrain_and_deploy, "LAST_TRAIN_FILE", soul_dir / "last_trained.txt")
+
+    calls = {}
+    monkeypatch.setattr(train_soul, "train_soul", lambda log, iterations: calls.setdefault("trained", iterations))
+    ml = SimpleNamespace(
+        start_run=lambda: calls.setdefault("start", True),
+        log_param=lambda *a, **k: calls.setdefault("param", a),
+        log_artifact=lambda *a, **k: calls.setdefault("artifact", a),
+        end_run=lambda: calls.setdefault("end", True),
+    )
+    monkeypatch.setattr(retrain_and_deploy, "mlflow", ml)
+    return model_dir, chroma_dir, calls
+
+
+def test_retrain_creates_artifact(tmp_path, monkeypatch):
+    model_dir, chroma_dir, calls = _prepare(tmp_path, monkeypatch)
+
+    retrain_and_deploy.retrain_and_deploy(iterations=1)
+
+    assert calls.get("trained") == 1
+    artifacts = list((model_dir / "soul").glob("*/soul.dna"))
+    assert artifacts
+    assert (model_dir / "soul" / "last_trained.txt").exists()
+
+
+def test_skip_when_no_new_embeddings(tmp_path, monkeypatch):
+    model_dir, chroma_dir, calls = _prepare(tmp_path, monkeypatch)
+    past = datetime.utcnow() - timedelta(days=1)
+    file_path = chroma_dir / "emb"
+    os.utime(file_path, (past.timestamp(), past.timestamp()))
+    retrain_and_deploy.LAST_TRAIN_FILE.write_text(datetime.utcnow().isoformat())
+
+    retrain_and_deploy.retrain_and_deploy(iterations=1)
+
+    assert "trained" not in calls
+


### PR DESCRIPTION
## Summary
- add MLflow-based retraining script and rollback helper
- run retraining on schedule or after data refresh workflow
- expose retraining module via package init
- add mlflow requirement
- test retraining script behaviour

## Testing
- `pytest tests/test_retrain_and_deploy.py -q`
- `pip install -r tests/requirements.txt` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687172371a04832ea80ff5f2ec682e8c