### PR TITLE
Replace Dockerfile with multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,36 @@
-FROM python:3.10-slim
+# syntax=docker/dockerfile:1
+FROM python:3.10-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+COPY requirements.txt .
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash inanna
+WORKDIR /home/inanna/app
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir --no-index --find-links=/wheels /wheels/* && \
+    rm -rf /wheels
+
 COPY . .
-CMD ["bash"]
+
+RUN chown -R inanna:inanna /home/inanna/app
+USER inanna
+
+HEALTHCHECK --interval=30s --timeout=3s CMD \
+    curl -f http://localhost:8000/health || exit 1
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
## Summary
- switch Dockerfile to multi-stage python:3.10-slim build
- create non-root user `inanna`
- install dependencies from wheels and run as the new user
- add healthcheck and run `server.py` by default

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68717a2e9630832e87cf2d1c09b2452a