### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ oracle_output/
 OPENAI_API_KEY.env
 INANNA_AI/models/
 secrets.env
+logs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  inanna_ai:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./logs:/home/inanna/app/logs
+    environment:
+      - CORPUS_MEMORY_PATH=/home/inanna/app/data/corpus_memory.json
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- ignore the new logs folder
- define an `inanna_ai` service in `docker-compose.yml`

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q` *(fails: ImportError: cannot import name 'get_emotional_weight')*

------
https://chatgpt.com/codex/tasks/task_e_68717b0edfe8832ea13a48519151ed43