### PR TITLE
Add FastAPI health endpoints

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,18 @@
+"""Simple FastAPI application for health checks."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    """Return service health status."""
+    return {"status": "alive"}
+
+
+@app.get("/ready")
+def readiness_check() -> dict[str, str]:
+    """Return service readiness status."""
+    return {"status": "ready"}


### PR DESCRIPTION
## Summary
- create `server.py` with a simple FastAPI app

## Testing
- `python -m py_compile server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stable_baselines3' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68718a4c378c832ea330c7f7b5811306