### PR TITLE
Document container deployment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ docker run -it spiral_os
 
 From there you can run any of the demo scripts such as `python run_song_demo.py`.
 
+To launch the FastAPI service directly, publish port `8000`:
+
+```bash
+docker run -p 8000:8000 spiral_os
+```
+
+Health endpoints are available at `/health` and `/ready`.  Logs are written to
+`logs/inanna_ai.log` inside the repository (mounted into the container when
+running with Docker or Compose).
+
+## Docker Compose
+
+Start the service with [docker-compose](docker-compose.yml):
+
+```bash
+docker-compose up --build
+```
+
+This exposes port `8000` and mounts the `logs` directory on the host. Stop the
+stack with `docker-compose down`.
+
 ## Codex GPU Deployment
 
 A container spec `spiral_os_container.yaml` is provided for running the tools with CUDA support. Build and launch it with:
@@ -45,3 +66,17 @@ codex run spiral_os_container.yaml
 ```
 
 This installs the requirements and creates empty folders for the CORPUS MEMORY collections.
+
+## Kubernetes Deployment
+
+The `k8s` directory contains manifests for running Spiral OS on a cluster. Deploy them with:
+
+```bash
+kubectl apply -f k8s/spiral_os_deployment.yaml
+kubectl apply -f k8s/spiral_os_service.yaml
+kubectl apply -f k8s/spiral_os_hpa.yaml
+```
+
+The deployment exposes port `8000` and defines readiness (`/ready`) and liveness
+(`/health`) probes. Container logs can be viewed with `kubectl logs` and are
+written to `logs/inanna_ai.log` inside the pod.


### PR DESCRIPTION
## Summary
- document how to build and run the Docker image
- add instructions for docker-compose usage
- describe Kubernetes deployment using manifests
- note health endpoints and log location

## Testing
- `pytest tests/test_spiral_os.py::test_deploy_pipeline_runs_commands -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68718afbde54832e823b52ef41120235