### PR TITLE
Add health endpoint test

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,3 +11,4 @@ pyopenssl
 streamlit
 stable-baselines3
 python-json-logger
+httpx

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import asyncio
+
+import httpx
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import server
+
+
+def test_health_and_ready_return_200():
+    """Endpoints should respond with HTTP 200 when app is running."""
+
+    async def run_requests() -> tuple[int, int]:
+        with TestClient(server.app) as test_client:
+            transport = httpx.ASGITransport(app=test_client.app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as client:
+                health = await client.get("/health")
+                ready = await client.get("/ready")
+        return health.status_code, ready.status_code
+
+    status_health, status_ready = asyncio.run(run_requests())
+    assert status_health == 200
+    assert status_ready == 200


### PR DESCRIPTION
## Summary
- test server health and readiness endpoints
- include `httpx` in test requirements

## Testing
- `pytest tests/test_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68718bd82128832e8f529094d7ff9f1f