### PR TITLE
Use run_inanna.sh as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ USER inanna
 HEALTHCHECK --interval=30s --timeout=3s CMD \
     curl -f http://localhost:8000/health || exit 1
 
-CMD ["python", "server.py"]
+ENTRYPOINT ["bash", "run_inanna.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ voicefixer==0.1.3
 requests
 beautifulsoup4
 streamlit
+fastapi
+uvicorn
 sentence-transformers  # optional, for semantic validation
 stable-baselines3
 chromadb

--- a/run_inanna.sh
+++ b/run_inanna.sh
@@ -7,6 +7,11 @@ if [ -f "secrets.env" ]; then
     set +a
 fi
 
+# Start the FastAPI health server in the background
+python -m uvicorn server:app --host 0.0.0.0 --port 8000 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID' EXIT
+
 # Check for required models before starting chat
 MODELS_DIR="INANNA_AI/models"
 if [ ! -d "$MODELS_DIR/DeepSeek-R1" ] && [ ! -d "$MODELS_DIR/gemma2" ]; then


### PR DESCRIPTION
## Summary
- run FastAPI health server from `run_inanna.sh`
- switch Dockerfile CMD to ENTRYPOINT
- include FastAPI and Uvicorn in requirements

## Testing
- `pip install -r tests/requirements.txt`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687191709f80832e8cbe0b08e79e84f2