### PR TITLE
Add symbolic intent parser

### DIFF
--- a/SPIRAL_OS/symbolic_parser.py
+++ b/SPIRAL_OS/symbolic_parser.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Intent parser and dispatcher for QNL-derived commands."""
+
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+import json
+
+from inanna_ai import corpus_memory, speaking_engine
+from SPIRAL_OS import seven_dimensional_music
+
+
+_INTENT_FILE = Path(__file__).resolve().parents[1] / "intent_matrix.json"
+try:
+    with open(_INTENT_FILE, "r", encoding="utf-8") as fh:
+        _INTENTS: Dict[str, Dict[str, Any]] = json.load(fh)
+except Exception:  # pragma: no cover - file may be missing
+    _INTENTS = {}
+
+_ACTIONS: Dict[str, Callable[[dict], Any]] = {}
+
+
+def register_action(name: str, func: Callable[[dict], Any]) -> None:
+    """Register ``func`` as handler for ``name``."""
+    _ACTIONS[name] = func
+
+
+def _gather_text(data: dict) -> str:
+    parts: List[str] = []
+    if isinstance(data.get("qnl_output"), list):
+        parts.extend(str(p) for p in data["qnl_output"])
+    if isinstance(data.get("phrases"), list):
+        parts.extend(str(p.get("phrase", "")) for p in data["phrases"])
+    if isinstance(data.get("structure"), list):
+        for p in data["structure"]:
+            if isinstance(p, dict):
+                parts.append(str(p.get("qnl_phrase", p.get("glyph", ""))))
+            else:
+                parts.append(str(p))
+    if "text" in data:
+        parts.append(str(data["text"]))
+    return " ".join(parts)
+
+
+def parse_intent(qnl_dict: dict) -> List[Any]:
+    """Dispatch actions matching QNL phrases in ``qnl_dict``."""
+    text = _gather_text(qnl_dict).lower()
+    results: List[Any] = []
+    for name, info in _INTENTS.items():
+        triggers = [name] + info.get("synonyms", []) + info.get("glyphs", [])
+        if any(t.lower() in text for t in triggers):
+            action = info.get("action")
+            func = _ACTIONS.get(action)
+            if func:
+                results.append(func(qnl_dict))
+            else:
+                results.append({"intent": name, "action": action, "status": "unhandled"})
+    return results
+
+
+# Built-in action handlers ---------------------------------------------------
+
+def _action_memory_recall(data: dict) -> Any:
+    query = _gather_text(data)
+    return corpus_memory.search_corpus(query, top_k=3)
+
+
+def _action_voice_play(data: dict) -> Any:
+    text = _gather_text(data)
+    emotion = data.get("tone", "neutral")
+    path = speaking_engine.synthesize_speech(text, emotion)
+    return path
+
+
+def _action_generate_music(data: dict) -> Any:
+    context = _gather_text(data)
+    emotion = data.get("tone", "neutral")
+    return seven_dimensional_music.generate_quantum_music(context, emotion)
+
+
+register_action("memory.recall", _action_memory_recall)
+register_action("voice_layer.play", _action_voice_play)
+register_action("music.generate", _action_generate_music)
+
+# Placeholders for additional actions
+for name in ["gateway.open", "elemental.fire", "signal.dispatch", "fusion.bind"]:
+    register_action(name, lambda d, _name=name: {"intent": _name, "status": "todo"})
+
+
+__all__ = ["parse_intent", "register_action"]
+

--- a/tests/test_symbolic_parser.py
+++ b/tests/test_symbolic_parser.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from SPIRAL_OS import symbolic_parser
+
+
+def test_parse_intent_memory(monkeypatch):
+    called = {}
+
+    def dummy_search(query, top_k=3, dirs=None, model_name="all-MiniLM-L6-v2"):
+        called['query'] = query
+        return [("p", "s")]
+
+    monkeypatch.setattr(symbolic_parser.corpus_memory, "search_corpus", dummy_search)
+
+    result = symbolic_parser.parse_intent({"text": "summon memory"})
+
+    assert called['query']
+    assert result == [[("p", "s")]]
+


### PR DESCRIPTION
## Summary
- implement `symbolic_parser.parse_intent` with dispatcher
- provide default actions for memory recall, voice playback and music generation
- add placeholder registrations for unused intents
- test basic intent dispatch

## Testing
- `python -m py_compile SPIRAL_OS/symbolic_parser.py tests/test_symbolic_parser.py`
- `pytest -k symbolic_parser -q` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*


------
https://chatgpt.com/codex/tasks/task_e_6871a872b020832e8c79c5a5ce5e341b