### PR TITLE
Add voice layer albedo

### DIFF
--- a/inanna_ai/voice_layer_albedo.py
+++ b/inanna_ai/voice_layer_albedo.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Voice modulation layer with alchemical tone presets."""
+
+from typing import Dict
+
+from . import speaking_engine, voice_evolution
+
+# Tone presets mapping to speed and pitch adjustments
+TONE_PRESETS: Dict[str, Dict[str, float]] = {
+    "albedo": {"speed": 1.05, "pitch": 0.2},
+    "nigredo": {"speed": 0.9, "pitch": -0.3},
+    "rubedo": {"speed": 1.1, "pitch": 0.5},
+    "lunar": {"speed": 0.95, "pitch": -0.4},
+}
+
+
+def _ensure_preset(tone: str) -> None:
+    """Inject preset ``tone`` into the voice evolution styles."""
+    preset = TONE_PRESETS.get(tone)
+    if not preset:
+        return
+    voice_evolution.DEFAULT_VOICE_STYLES.setdefault(tone, preset)
+    voice_evolution._evolver.styles.setdefault(tone, preset)
+
+
+def modulate_voice(text: str, tone: str) -> str:
+    """Synthesize ``text`` using the style defined by ``tone``."""
+    tone = tone.lower()
+    _ensure_preset(tone)
+    return speaking_engine.synthesize_speech(text, tone)
+
+
+__all__ = ["modulate_voice", "TONE_PRESETS"]

--- a/tests/test_voice_layer_albedo.py
+++ b/tests/test_voice_layer_albedo.py
@@ -1,0 +1,42 @@
+import sys
+import types
+
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("openvoice", types.ModuleType("openvoice"))
+sys.modules.setdefault("gtts", types.ModuleType("gtts"))
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from inanna_ai import voice_layer_albedo, voice_evolution
+
+
+def test_modulate_voice_adds_preset_and_calls_synth(monkeypatch):
+    calls = {}
+
+    def fake_synth(text: str, tone: str, history=None, timbre='neutral'):
+        calls['args'] = (text, tone)
+        return 'out.wav'
+
+    monkeypatch.setattr(voice_layer_albedo.speaking_engine, 'synthesize_speech', fake_synth)
+
+    path = voice_layer_albedo.modulate_voice('hello', 'lunar')
+    assert path == 'out.wav'
+    assert calls['args'] == ('hello', 'lunar')
+    assert voice_evolution.get_voice_params('lunar') == voice_layer_albedo.TONE_PRESETS['lunar']
+
+
+def test_modulate_voice_unknown_tone(monkeypatch):
+    monkeypatch.setattr(voice_layer_albedo.speaking_engine, 'synthesize_speech', lambda t, e: 'x.wav')
+    before = dict(voice_evolution._evolver.styles)
+    path = voice_layer_albedo.modulate_voice('hi', 'mystic')
+    assert path == 'x.wav'
+    assert 'mystic' not in voice_evolution._evolver.styles
+    voice_evolution._evolver.styles = before
+
+


### PR DESCRIPTION
## Summary
- introduce `inanna_ai/voice_layer_albedo.py` providing voice tone presets and `modulate_voice`
- test that presets are injected and that modulation calls through to the speaking engine

## Testing
- `pytest tests/test_voice_layer_albedo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871aa72ea60832e8a02d26f7a9095be