### PR TITLE
Add qnl and intent parser tests

### DIFF
--- a/tests/test_qnl_parser.py
+++ b/tests/test_qnl_parser.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "SPIRAL_OS"))
+
+from qnl_engine import parse_input
+
+
+def test_parse_input_keyword_low_urgency():
+    data = parse_input("remember our memory soon?")
+    assert data == {
+        "type": "question",
+        "object": "text",
+        "tone": "Memory",
+        "urgency": "low",
+        "linked_memory": None,
+    }
+
+
+def test_parse_input_glyph_and_memory_link():
+    data = parse_input("Summon ❣⟁ now! #3")
+    assert data == {
+        "type": "statement",
+        "object": "glyph_sequence",
+        "tone": "Longing",
+        "urgency": "high",
+        "linked_memory": "3",
+    }
+
+
+def test_parse_input_keyword_default():
+    data = parse_input("joy awakens")
+    assert data == {
+        "type": "statement",
+        "object": "text",
+        "tone": "Joy",
+        "urgency": "normal",
+        "linked_memory": None,
+    }

--- a/tests/test_symbolic_parser.py
+++ b/tests/test_symbolic_parser.py
@@ -1,8 +1,17 @@
 import sys
+import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+# Stub heavy optional dependencies before importing the module
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("openvoice", types.ModuleType("openvoice"))
+sys.modules.setdefault("gtts", types.ModuleType("gtts"))
 
 from SPIRAL_OS import symbolic_parser
 
@@ -21,3 +30,29 @@ def test_parse_intent_memory(monkeypatch):
     assert called['query']
     assert result == [[("p", "s")]]
 
+
+
+def test_parse_intent_voice(monkeypatch):
+    calls = {}
+
+    def fake_speak(text: str, emotion: str):
+        calls['args'] = (text, emotion)
+        return 'v.wav'
+
+    monkeypatch.setattr(symbolic_parser.speaking_engine, 'synthesize_speech', fake_speak)
+    result = symbolic_parser.parse_intent({'text': 'weave sound', 'tone': 'joy'})
+    assert result == ['v.wav']
+    assert calls['args'] == ('weave sound', 'joy')
+
+
+def test_parse_intent_placeholder(monkeypatch):
+    called = {}
+
+    def fake_open(data):
+        called['data'] = data
+        return 'ok'
+
+    monkeypatch.setitem(symbolic_parser._ACTIONS, 'gateway.open', fake_open)
+    result = symbolic_parser.parse_intent({'text': 'open portal'})
+    assert result == ['ok']
+    assert called['data']['text'] == 'open portal'


### PR DESCRIPTION
## Summary
- test parse_input() directly in `test_qnl_parser.py`
- extend `test_symbolic_parser` with voice and gateway intents
- ensure optional dependencies are stubbed for import

## Testing
- `pytest -q tests/test_qnl_parser.py tests/test_symbolic_parser.py tests/test_voice_layer_albedo.py`

------
https://chatgpt.com/codex/tasks/task_e_6871ae78811c832eafa896e5ba230f83