### PR TITLE
Add training feedback logger

### DIFF
--- a/tests/test_training_guide_logger.py
+++ b/tests/test_training_guide_logger.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import training_guide
+
+
+def test_log_result_writes_json_and_db(tmp_path, monkeypatch):
+    entries = []
+    monkeypatch.setattr(training_guide, "FEEDBACK_FILE", tmp_path / "f.json")
+
+    def fake_log(emotion, sat, align, clear, db_path=training_guide.db_storage.DB_PATH):
+        entries.append((emotion, sat, align, clear))
+
+    monkeypatch.setattr(training_guide.db_storage, "log_feedback", fake_log)
+
+    intent = {"intent": "open", "action": "gateway.open"}
+    training_guide.log_result(intent, True, "joy")
+    training_guide.log_result(intent, False, None)
+
+    data = json.loads((tmp_path / "f.json").read_text())
+    assert len(data) == 2
+    assert data[0]["success"] is True
+    assert data[1]["tone"] is None
+    assert entries == [("joy", 1.0, 1.0, 1.0), ("neutral", 0.0, 0.0, 0.0)]

--- a/training_guide.py
+++ b/training_guide.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Log intent outcomes for reinforcement learning.
+
+Entries are appended to ``data/feedback.json`` as dictionaries with the
+following keys:
+``timestamp`` ISO‑8601 time of the event,
+``intent`` intent name,
+``action`` handler action name,
+``tone`` tonal label if provided,
+``success`` boolean result indicator.
+"""
+
+from pathlib import Path
+from datetime import datetime
+import json
+
+from inanna_ai import db_storage
+
+FEEDBACK_FILE = Path("data/feedback.json")
+
+
+def _load_entries() -> list[dict]:
+    if FEEDBACK_FILE.exists():
+        try:
+            return json.loads(FEEDBACK_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+    return []
+
+
+def log_result(intent: dict, success: bool, tone: str | None) -> None:
+    """Append ``intent`` outcome to the feedback log."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "intent": intent.get("intent"),
+        "action": intent.get("action"),
+        "tone": tone,
+        "success": bool(success),
+    }
+    entries = _load_entries()
+    entries.append(entry)
+    FEEDBACK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    FEEDBACK_FILE.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+
+    score = 1.0 if success else 0.0
+    db_storage.log_feedback(tone or "neutral", score, score, score)


### PR DESCRIPTION
## Summary
- create new `training_guide.py` with `log_result`
- record handled intents in orchestrator
- test feedback logging

## Testing
- `pytest tests/test_training_guide_logger.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*

------
https://chatgpt.com/codex/tasks/task_e_6871bf261c6c832e94a49017a8dcc4c0