### PR TITLE
Implement voice speak and music sequence functions

### DIFF
--- a/SPIRAL_OS/seven_dimensional_music.py
+++ b/SPIRAL_OS/seven_dimensional_music.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import tempfile
 from typing import List, Tuple, Optional
 import json
 
@@ -182,9 +183,10 @@ def generate_quantum_music(
     return out_path
 
 
-def play_sequence(sequence: str, emotion: str, *, output_dir: str | Path = ".") -> Path:
-    """Play a short musical sequence via :func:`generate_quantum_music`."""
-    return generate_quantum_music(sequence, emotion, output_dir=output_dir)
+def play_sequence(name: str, mood: str) -> str:
+    """Generate a short clip using ``name`` and ``mood``."""
+    out = generate_quantum_music(name, mood, output_dir=tempfile.gettempdir())
+    return str(out)
 
 
 def reactive_music_loop(

--- a/SPIRAL_OS/symbolic_parser.py
+++ b/SPIRAL_OS/symbolic_parser.py
@@ -79,7 +79,7 @@ def _action_memory_recall(data: dict) -> Any:
 def _action_voice_play(data: dict) -> Any:
     text = _gather_text(data)
     emotion = data.get("tone", "neutral")
-    return voice_layer_albedo.modulate_voice(text, emotion)
+    return voice_layer_albedo.speak(text, emotion)
 
 
 def _action_generate_music(data: dict) -> Any:

--- a/inanna_ai/voice_layer_albedo.py
+++ b/inanna_ai/voice_layer_albedo.py
@@ -31,4 +31,11 @@ def modulate_voice(text: str, tone: str) -> str:
     return speaking_engine.synthesize_speech(text, tone)
 
 
-__all__ = ["modulate_voice", "TONE_PRESETS"]
+def speak(text: str, tone: str) -> str:
+    """Synthesize and immediately play ``text`` with ``tone``."""
+    path = modulate_voice(text, tone)
+    speaking_engine.play_wav(path)
+    return path
+
+
+__all__ = ["modulate_voice", "speak", "TONE_PRESETS"]

--- a/tests/test_symbolic_parser.py
+++ b/tests/test_symbolic_parser.py
@@ -35,11 +35,11 @@ def test_parse_intent_memory(monkeypatch):
 def test_parse_intent_voice(monkeypatch):
     calls = {}
 
-    def fake_modulate(text: str, tone: str):
+    def fake_speak(text: str, tone: str):
         calls['args'] = (text, tone)
         return 'v.wav'
 
-    monkeypatch.setattr(symbolic_parser.voice_layer_albedo, 'modulate_voice', fake_modulate)
+    monkeypatch.setattr(symbolic_parser.voice_layer_albedo, 'speak', fake_speak)
     result = symbolic_parser.parse_intent({'text': 'weave sound', 'tone': 'joy'})
     assert result == ['v.wav']
     assert calls['args'] == ('weave sound', 'joy')
@@ -75,11 +75,11 @@ def test_route_intent_memory(monkeypatch):
 def test_route_intent_voice(monkeypatch):
     calls = {}
 
-    def fake_modulate(text: str, tone: str):
+    def fake_speak(text: str, tone: str):
         calls['args'] = (text, tone)
         return 'p.wav'
 
-    monkeypatch.setattr(symbolic_parser.voice_layer_albedo, 'modulate_voice', fake_modulate)
+    monkeypatch.setattr(symbolic_parser.voice_layer_albedo, 'speak', fake_speak)
     intent = {'intent': 'play', 'action': 'voice_layer.play', 'text': 'beta', 'tone': 'joy'}
     result = symbolic_parser.route_intent(intent)
     assert result == 'p.wav'
@@ -91,12 +91,12 @@ def test_route_intent_music(monkeypatch):
 
     def fake_play(seq: str, emo: str):
         calls['args'] = (seq, emo)
-        return Path('x.wav')
+        return 'x.wav'
 
     monkeypatch.setattr(symbolic_parser.seven_dimensional_music, 'play_sequence', fake_play)
     intent = {'intent': 'play', 'action': 'music.play_sequence', 'text': 'notes', 'tone': 'calm'}
     result = symbolic_parser.route_intent(intent)
-    assert result == Path('x.wav')
+    assert result == 'x.wav'
     assert calls['args'] == ('notes', 'calm')
 
 

--- a/tests/test_voice_layer_albedo.py
+++ b/tests/test_voice_layer_albedo.py
@@ -40,3 +40,21 @@ def test_modulate_voice_unknown_tone(monkeypatch):
     voice_evolution._evolver.styles = before
 
 
+def test_speak_uses_modulate_and_play(monkeypatch):
+    events = {}
+
+    def fake_modulate(text: str, tone: str) -> str:
+        events['mod'] = (text, tone)
+        return 'v.wav'
+
+    def fake_play(path: str) -> None:
+        events['play'] = path
+
+    monkeypatch.setattr(voice_layer_albedo, 'modulate_voice', fake_modulate)
+    monkeypatch.setattr(voice_layer_albedo.speaking_engine, 'play_wav', fake_play)
+    out = voice_layer_albedo.speak('hi', 'calm')
+    assert out == 'v.wav'
+    assert events['mod'] == ('hi', 'calm')
+    assert events['play'] == 'v.wav'
+
+


### PR DESCRIPTION
## Summary
- extend `inanna_ai.voice_layer_albedo` with a `speak` helper that plays audio
- add `play_sequence` in `seven_dimensional_music` for quick clip generation
- route symbolic parser actions through the new helpers
- update related unit tests

## Testing
- `pytest tests/test_voice_layer_albedo.py -q`
- `pytest tests/test_symbolic_parser.py::test_route_intent_music tests/test_symbolic_parser.py::test_route_intent_voice tests/test_symbolic_parser.py::test_parse_intent_voice -q`


------
https://chatgpt.com/codex/tasks/task_e_6871c0acf18c832eac63913b25da43ee