### PR TITLE
Update docs for orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ pip install -r dev-requirements.txt
    python start_spiral_os.py
    ```
 
+## Orchestration Engine
+
+`start_spiral_os.py` launches the **MoGEOrchestrator** which routes text
+commands to the available models.  Start it with an optional network
+interface to capture packets and an optional personality layer:
+
+```bash
+python start_spiral_os.py --interface eth0 --personality albedo
+```
+
+After initialization the script enters an interactive loop where you can
+type commands.  Supply `--command` to send an initial instruction or press
+`Enter` to exit.  Processing results are written to several files under
+`INANNA_AI/audit_logs` and intent outcomes are appended to
+`data/feedback.json` for later training.
+
+To deploy the orchestrator in a container use the Kubernetes manifest
+[`k8s/spiral_os_deployment.yaml`](k8s/spiral_os_deployment.yaml).
+
 ## QNL Engine
 
 The QNL engine converts hexadecimal strings into symbolic soundscapes.

--- a/README_CODE_FUNCTION.md
+++ b/README_CODE_FUNCTION.md
@@ -16,6 +16,13 @@ For an overview of the Albedo personality layer see [docs/ALBEDO_LAYER.md](docs/
   `voice_evolution` and wraps `speaking_engine.synthesize_speech` to
   produce modulated output.
 
+- **Tone presets** – The module defines four preset voices used when
+  generating speech:
+  - `albedo` – speed 1.05, pitch +0.2
+  - `nigredo` – speed 0.9, pitch -0.3
+  - `rubedo` – speed 1.1, pitch +0.5
+  - `lunar` – speed 0.95, pitch -0.4
+
 ## MUSIC_FOUNDATION modules
 
 - **`inanna_music_COMPOSER_ai.py`** – Stand‑alone converter that loads an MP3, analyzes tempo and chroma, and outputs QNL phrases and a preview WAV.


### PR DESCRIPTION
## Summary
- add Orchestration Engine section explaining `start_spiral_os.py`
- document feedback log path
- list tone presets for the voice layer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6871c2799e8c832eb56f3d4325b22eb7