### PR TITLE
Add orchestrator handle and training guide tests

### DIFF
--- a/tests/test_orchestrator_handle.py
+++ b/tests/test_orchestrator_handle.py
@@ -1,0 +1,45 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy optional dependencies before importing the module
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+import orchestrator
+from orchestrator import MoGEOrchestrator
+
+
+def test_handle_input_updates_mood(monkeypatch):
+    events = {}
+
+    def fake_parse(text):
+        events['parse'] = text
+        return {'tone': 'joy'}
+
+    def fake_intent(data):
+        events['intent'] = data
+        return ['ok']
+
+    def fake_route(self, text, emotion_data, *, qnl_data=None, **kwargs):
+        events['route'] = emotion_data
+        return {'handled': True}
+
+    monkeypatch.setattr(orchestrator.qnl_engine, 'parse_input', fake_parse)
+    monkeypatch.setattr(orchestrator.symbolic_parser, 'parse_intent', fake_intent)
+    monkeypatch.setattr(MoGEOrchestrator, 'route', fake_route)
+
+    orch = MoGEOrchestrator()
+    joy_before = orch.mood_state.get('joy', 0.0)
+    neutral_before = orch.mood_state.get('neutral', 0.0)
+
+    result = orch.handle_input('hello')
+
+    assert events['parse'] == 'hello'
+    assert events['intent'] == {'tone': 'joy'}
+    assert result == {'handled': True}
+    assert orch.mood_state['joy'] > joy_before
+    assert orch.mood_state['neutral'] < neutral_before

--- a/tests/test_training_feedback.py
+++ b/tests/test_training_feedback.py
@@ -1,0 +1,27 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import training_guide
+
+
+def test_log_result_json_and_db(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(training_guide, 'FEEDBACK_FILE', tmp_path / 'feed.json')
+
+    def fake_log(emotion, sat, align, clear, db_path=training_guide.db_storage.DB_PATH):
+        calls.append((emotion, sat, align, clear))
+
+    monkeypatch.setattr(training_guide.db_storage, 'log_feedback', fake_log)
+
+    intent = {'intent': 'open', 'action': 'gateway.open'}
+    training_guide.log_result(intent, True, 'joy')
+
+    data = json.loads((tmp_path / 'feed.json').read_text())
+    assert isinstance(data, list) and data
+    assert data[0]['intent'] == 'open'
+    assert data[0]['success'] is True
+    assert calls == [('joy', 1.0, 1.0, 1.0)]


### PR DESCRIPTION
## Summary
- check that `handle_input` updates mood state while calling parsers
- ensure feedback logger writes JSON and logs to database

## Testing
- `pytest tests/test_orchestrator_handle.py tests/test_training_feedback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c382f28c832e88942cd76574f44f