### PR TITLE
Add JSONL interaction logging

### DIFF
--- a/corpus_memory_logging.py
+++ b/corpus_memory_logging.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Append and read JSONL interaction records for corpus memory usage."""
+
+from pathlib import Path
+from datetime import datetime
+import json
+from typing import Any, List
+
+INTERACTIONS_FILE = Path("data/interactions.jsonl")
+
+
+def log_interaction(input_text: str, intent: dict, result: dict, outcome: str) -> None:
+    """Append ``input_text`` and ``result`` details to :data:`INTERACTIONS_FILE`."""
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "input": input_text,
+        "intent": intent,
+        "result": result,
+        "outcome": outcome,
+    }
+    emotion = result.get("emotion") or intent.get("emotion")
+    if emotion is not None:
+        entry["emotion"] = emotion
+    INTERACTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with INTERACTIONS_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False))
+        fh.write("\n")
+
+
+def load_interactions(limit: int | None = None) -> List[dict[str, Any]]:
+    """Return recorded interactions ordered from oldest to newest."""
+    if not INTERACTIONS_FILE.exists():
+        return []
+    entries: List[dict[str, Any]] = []
+    with INTERACTIONS_FILE.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                entries.append(json.loads(line))
+            except Exception:
+                continue
+    if limit is not None:
+        entries = entries[-limit:]
+    return entries
+
+
+__all__ = ["log_interaction", "load_interactions", "INTERACTIONS_FILE"]

--- a/tests/test_corpus_memory_logging.py
+++ b/tests/test_corpus_memory_logging.py
@@ -1,0 +1,28 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import corpus_memory_logging as cml
+
+
+def test_log_and_load(tmp_path, monkeypatch):
+    log_path = tmp_path / "interactions.jsonl"
+    monkeypatch.setattr(cml, "INTERACTIONS_FILE", log_path)
+
+    cml.log_interaction("hello", {"intent": "greet", "emotion": "joy"}, {}, "ok")
+    cml.log_interaction("bye", {"intent": "exit"}, {"emotion": "calm"}, "done")
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["input"] == "hello" and first["emotion"] == "joy"
+
+    all_entries = cml.load_interactions()
+    assert len(all_entries) == 2
+    assert all_entries[-1]["outcome"] == "done"
+
+    limited = cml.load_interactions(limit=1)
+    assert limited == all_entries[-1:]


### PR DESCRIPTION
## Summary
- implement `corpus_memory_logging` to append/read JSONL entries
- test logger behaviour in `test_corpus_memory_logging`

## Testing
- `pytest tests/test_corpus_memory_logging.py -q`
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6871c574f984832e9bb28a28d8d68af8