### PR TITLE
Add result evaluation metrics

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -205,7 +205,7 @@ class MoGEOrchestrator:
                 isinstance(res, dict)
                 and res.get("status") in {"unhandled", "todo"}
             )
-            training_guide.log_result(intent, success, qnl_data.get("tone"))
+            training_guide.log_result(intent, success, qnl_data.get("tone"), res)
         emotion = qnl_data.get("tone", "neutral")
         self._update_mood(emotion)
         dominant = max(self.mood_state, key=self.mood_state.get)

--- a/tests/test_training_feedback.py
+++ b/tests/test_training_feedback.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,10 +19,22 @@ def test_log_result_json_and_db(tmp_path, monkeypatch):
     monkeypatch.setattr(training_guide.db_storage, 'log_feedback', fake_log)
 
     intent = {'intent': 'open', 'action': 'gateway.open'}
-    training_guide.log_result(intent, True, 'joy')
+    training_guide.log_result(intent, True, 'joy', {'text': 'open sesame'})
 
     data = json.loads((tmp_path / 'feed.json').read_text())
     assert isinstance(data, list) and data
     assert data[0]['intent'] == 'open'
     assert data[0]['success'] is True
+    assert 'response_quality' in data[0] and 'memory_overlap' in data[0]
     assert calls == [('joy', 1.0, 1.0, 1.0)]
+
+
+def test_evaluate_action_metrics(monkeypatch):
+    def fake_load(limit=None):
+        return [{'input': 'hello world'}]
+
+    mod = types.SimpleNamespace(load_interactions=fake_load)
+    monkeypatch.setitem(sys.modules, 'corpus_memory_logging', mod)
+
+    out = training_guide.evaluate_action({'intent': 'hello'}, {'text': 'hello there'})
+    assert set(out) == {'response_quality', 'memory_overlap'}

--- a/tests/test_training_guide_logger.py
+++ b/tests/test_training_guide_logger.py
@@ -18,11 +18,12 @@ def test_log_result_writes_json_and_db(tmp_path, monkeypatch):
     monkeypatch.setattr(training_guide.db_storage, "log_feedback", fake_log)
 
     intent = {"intent": "open", "action": "gateway.open"}
-    training_guide.log_result(intent, True, "joy")
-    training_guide.log_result(intent, False, None)
+    training_guide.log_result(intent, True, "joy", {"text": "open"})
+    training_guide.log_result(intent, False, None, {"text": "fail"})
 
     data = json.loads((tmp_path / "f.json").read_text())
     assert len(data) == 2
     assert data[0]["success"] is True
     assert data[1]["tone"] is None
+    assert "response_quality" in data[0] and "memory_overlap" in data[0]
     assert entries == [("joy", 1.0, 1.0, 1.0), ("neutral", 0.0, 0.0, 0.0)]


### PR DESCRIPTION
## Summary
- compute response_quality and memory_overlap in `evaluate_action`
- merge evaluation metrics into `log_result`
- pass results from orchestrator to the logger
- test evaluation behaviour in feedback utilities

## Testing
- `pytest tests/test_training_feedback.py tests/test_training_guide_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871de90ea28832e8bddf64d1f34cab6