### PR TITLE
Add vector memory with time decay

### DIFF
--- a/tests/test_corpus_memory.py
+++ b/tests/test_corpus_memory.py
@@ -69,6 +69,12 @@ def test_cli_search(tmp_path, monkeypatch, capsys):
 
     corpus_memory.reindex_corpus()
 
+    monkeypatch.setattr(
+        corpus_memory.vector_memory,
+        "search",
+        lambda q, filter=None, k=10: [{"text": "A magical unicorn appears.", "tone": ""}],
+    )
+
     argv_backup = sys.argv.copy()
     sys.argv = ["corpus_memory", "--search", "unicorn", "--top", "1"]
     try:
@@ -77,7 +83,7 @@ def test_cli_search(tmp_path, monkeypatch, capsys):
         sys.argv = argv_backup
 
     out = capsys.readouterr().out.lower()
-    assert "found.md" in out
+    assert "magical unicorn" in out
 
 
 def test_cli_reindex_runs(monkeypatch):
@@ -105,7 +111,12 @@ def test_cli_reindex_with_search(monkeypatch):
     monkeypatch.setattr(
         corpus_memory,
         "search_corpus",
-        lambda *a, **k: called.__setitem__("search", True) or [("p", "s")],
+        lambda *a, **k: called.__setitem__("search_corpus", True) or [("p", "s")],
+    )
+    monkeypatch.setattr(
+        corpus_memory,
+        "search",
+        lambda *a, **k: called.__setitem__("search", True) or [{"text": "x", "tone": ""}],
     )
 
     argv_backup = sys.argv.copy()

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from datetime import datetime, timedelta
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import vector_memory
+
+
+def test_add_and_search(monkeypatch, tmp_path):
+    records = []
+
+    class DummyCollection:
+        def add(self, ids, embeddings, metadatas):
+            for e, m in zip(embeddings, metadatas):
+                records.append((np.asarray(e, dtype=float), m))
+
+        def query(self, query_embeddings, n_results, **_):
+            q = np.asarray(query_embeddings[0], dtype=float)
+            sims = [float(e @ q / ((np.linalg.norm(e) * np.linalg.norm(q)) + 1e-8)) for e, _ in records]
+            order = np.argsort(sims)[::-1][:n_results]
+            return {
+                "embeddings": [[records[i][0].tolist() for i in order]],
+                "metadatas": [[records[i][1] for i in order]],
+            }
+
+    class DummyClient:
+        def __init__(self, path):
+            self.col = DummyCollection()
+
+        def get_or_create_collection(self, name):
+            return self.col
+
+    dummy_chroma = SimpleNamespace(PersistentClient=lambda path: DummyClient(path))
+
+    monkeypatch.setattr(vector_memory, "chromadb", dummy_chroma)
+    monkeypatch.setattr(vector_memory, "_DIR", tmp_path)
+
+    def fake_embed(text):
+        return np.array([len(text), text.count("b")], dtype=float)
+
+    monkeypatch.setattr(vector_memory.qnl_utils, "quantum_embed", fake_embed)
+
+    now = datetime.utcnow()
+    vector_memory.add_vector("aaaa", {"emotion": "joy", "timestamp": (now - timedelta(days=1)).isoformat()})
+    vector_memory.add_vector("aaa", {"emotion": "joy", "timestamp": now.isoformat()})
+    vector_memory.add_vector("bbb", {"emotion": "sad", "timestamp": now.isoformat()})
+
+    res = vector_memory.search("aaaaa", filter={"emotion": "joy"}, k=2)
+    assert [r["text"] for r in res] == ["aaa", "aaaa"]


### PR DESCRIPTION
## Summary
- implement a Chroma‑based vector store with time decay and filtering
- hook corpus_memory to new API
- adjust corpus_memory tests
- add dedicated unit test for vector_memory

## Testing
- `pytest tests/test_corpus_memory.py -q`
- `pytest tests/test_corpus_memory_extended.py -q`
- `pytest tests/test_vector_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872315d3278832e8165017ed5f34e3c