### PR TITLE
Add auto retrain utility

### DIFF
--- a/auto_retrain.py
+++ b/auto_retrain.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Automatically trigger fine-tuning based on feedback metrics."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+INSIGHT_FILE = Path("insight_matrix.json")
+FEEDBACK_FILE = Path("data/feedback.json")
+
+NOVELTY_THRESHOLD = 0.3
+COHERENCE_THRESHOLD = 0.7
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def compute_metrics(insights: dict, feedback: Iterable[dict]) -> tuple[float, float]:
+    """Return novelty and coherence scores from feedback."""
+    entries = list(feedback)
+    if not entries:
+        return 0.0, 0.0
+
+    known = set(insights)
+    intents = [e.get("intent") for e in entries if e.get("intent")]
+    new = sum(1 for i in intents if i not in known)
+    novelty = new / len(intents) if intents else 0.0
+
+    scores = [e.get("response_quality", 0.0) for e in entries]
+    coherence = sum(scores) / len(scores) if scores else 0.0
+    return novelty, coherence
+
+
+def build_dataset(feedback: Iterable[dict]) -> list[dict]:
+    """Return a fine-tuning dataset from successful feedback entries."""
+    dataset = []
+    for entry in feedback:
+        if entry.get("success") and entry.get("intent") and entry.get("action"):
+            dataset.append({"prompt": entry["intent"], "completion": entry["action"]})
+    return dataset
+
+
+def system_idle() -> bool:
+    """Return ``True`` if no training lock file exists."""
+    return not Path("training.lock").exists()
+
+
+def trigger_finetune(dataset: list[dict]) -> None:
+    """Invoke the LLM fine-tuning API with ``dataset``."""
+    import llm_api
+
+    llm_api.fine_tune(dataset)
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Automatically retrain model")
+    parser.add_argument("--run", action="store_true", help="Execute fine-tuning")
+    parser.add_argument("--dry-run", action="store_true", help="Show dataset only")
+    args = parser.parse_args(argv)
+
+    insights = _load_json(INSIGHT_FILE, {})
+    feedback = _load_json(FEEDBACK_FILE, [])
+
+    novelty, coherence = compute_metrics(insights, feedback)
+    print(f"Novelty: {novelty:.2f} Coherence: {coherence:.2f}")
+
+    if novelty >= NOVELTY_THRESHOLD and coherence >= COHERENCE_THRESHOLD and system_idle():
+        dataset = build_dataset(feedback)
+        if args.run:
+            trigger_finetune(dataset)
+            print("Fine-tuning triggered")
+        else:
+            print(json.dumps(dataset, indent=2))
+    else:
+        print("Conditions not met")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/tests/test_auto_retrain.py
+++ b/tests/test_auto_retrain.py
@@ -1,0 +1,56 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import auto_retrain
+
+
+def test_build_dataset():
+    feedback = [
+        {"intent": "open", "action": "door", "success": True},
+        {"intent": "close", "action": "door", "success": True},
+        {"intent": "fail", "action": "door", "success": False},
+    ]
+    ds = auto_retrain.build_dataset(feedback)
+    assert ds == [
+        {"prompt": "open", "completion": "door"},
+        {"prompt": "close", "completion": "door"},
+    ]
+
+
+def test_main_invokes_api(tmp_path, monkeypatch):
+    insight = {}
+    feedback = [
+        {
+            "intent": "open",
+            "action": "door",
+            "success": True,
+            "response_quality": 1.0,
+            "memory_overlap": 0.0,
+        }
+    ]
+    ins = tmp_path / "insight.json"
+    ins.write_text(json.dumps(insight), encoding="utf-8")
+    fb = tmp_path / "feed.json"
+    fb.write_text(json.dumps(feedback), encoding="utf-8")
+    monkeypatch.setattr(auto_retrain, "INSIGHT_FILE", ins)
+    monkeypatch.setattr(auto_retrain, "FEEDBACK_FILE", fb)
+    monkeypatch.setattr(auto_retrain, "NOVELTY_THRESHOLD", 0.0)
+    monkeypatch.setattr(auto_retrain, "COHERENCE_THRESHOLD", 0.0)
+    monkeypatch.setattr(auto_retrain, "system_idle", lambda: True)
+
+    calls = {}
+
+    def fake_ft(data):
+        calls["data"] = data
+
+    dummy_api = SimpleNamespace(fine_tune=fake_ft)
+    monkeypatch.setitem(sys.modules, "llm_api", dummy_api)
+
+    auto_retrain.main(["--run"])
+
+    assert calls.get("data") == [{"prompt": "open", "completion": "door"}]


### PR DESCRIPTION
## Summary
- implement `auto_retrain.py` for automatic fine-tuning triggers
- add CLI flags for dry run and execution
- create unit tests covering dataset building and API invocation

## Testing
- `pytest -q tests/test_auto_retrain.py`

------
https://chatgpt.com/codex/tasks/task_e_687233338398832e912e155506451923