### PR TITLE
Trigger auto retrain from log_result

### DIFF
--- a/tests/test_training_guide_trigger.py
+++ b/tests/test_training_guide_trigger.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import training_guide
+
+
+def test_auto_retrain_called(tmp_path, monkeypatch):
+    feed = tmp_path / "feedback.json"
+    insight = tmp_path / "insight.json"
+    feed.write_text("[]", encoding="utf-8")
+    insight.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(training_guide, "FEEDBACK_FILE", feed)
+    monkeypatch.setattr(training_guide.auto_retrain, "INSIGHT_FILE", insight)
+    monkeypatch.setattr(training_guide, "AUTO_RETRAIN_THRESHOLD", 1)
+    calls = []
+    monkeypatch.setattr(training_guide.auto_retrain, "main", lambda args: calls.append(args))
+    monkeypatch.setattr(training_guide.db_storage, "log_feedback", lambda *a, **k: None)
+
+    intent = {"intent": "open", "action": "gateway.open"}
+    training_guide.log_result(intent, True, "joy", {"text": "open"})
+
+    assert calls == [["--run"]]


### PR DESCRIPTION
## Summary
- call the auto retrain routine when new insights exceed a threshold
- expose `AUTO_RETRAIN_THRESHOLD` and helper to count unseen intents
- test that auto retrain is triggered once the threshold is hit

## Testing
- `pytest tests/test_training_guide_trigger.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: stable_baselines3 et al.)*

------
https://chatgpt.com/codex/tasks/task_e_687234653098832e9837a39994805935