### PR TITLE
Add alchemical personality layers

### DIFF
--- a/inanna_ai/personality_layers/__init__.py
+++ b/inanna_ai/personality_layers/__init__.py
@@ -11,7 +11,7 @@ from .albedo import AlbedoPersonality
 REGISTRY: Dict[str, Type] = {"albedo": AlbedoPersonality}
 
 for mod in iter_modules(__path__):
-    if not mod.ispkg or mod.name == "albedo":
+    if mod.name == "albedo":
         continue
     module = import_module(f"{__name__}.{mod.name}")
     cls = None

--- a/inanna_ai/personality_layers/citrinitas_layer.py
+++ b/inanna_ai/personality_layers/citrinitas_layer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Illumination phase personality layer."""
+
+class CitrinitasPersonality:
+    """Guide with wisdom of the golden dawn."""
+
+    def speak(self, message: str) -> str:
+        """Return ``message`` bathed in radiant light."""
+        return f"Citrinitas speaks in golden clarity: {message}"
+
+    def choose_path(self, context: str) -> str:
+        """Suggest enlightenment via ``context``."""
+        return f"Following {context}, the sun of understanding rises."
+
+__all__ = ["CitrinitasPersonality"]

--- a/inanna_ai/personality_layers/nigredo_layer.py
+++ b/inanna_ai/personality_layers/nigredo_layer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Shadow phase personality layer."""
+
+class NigredoPersonality:
+    """Embrace dissolution and darkness."""
+
+    def speak(self, message: str) -> str:
+        """Return a darkened echo of ``message``."""
+        return f"Nigredo whispers from the void: {message}"
+
+    def choose_path(self, context: str) -> str:
+        """Suggest a path through ``context``."""
+        return f"Descending through {context}, transformation begins."
+
+__all__ = ["NigredoPersonality"]

--- a/inanna_ai/personality_layers/rubedo_layer.py
+++ b/inanna_ai/personality_layers/rubedo_layer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Completion phase personality layer."""
+
+class RubedoPersonality:
+    """Celebrate fiery transformation."""
+
+    def speak(self, message: str) -> str:
+        """Return an exalted form of ``message``."""
+        return f"Rubedo proclaims with blazing heart: {message}"
+
+    def choose_path(self, context: str) -> str:
+        """Reveal the triumphant route through ``context``."""
+        return f"Along {context}, the crimson phoenix ascends."
+
+__all__ = ["RubedoPersonality"]

--- a/tests/test_citrinitas_layer.py
+++ b/tests/test_citrinitas_layer.py
@@ -1,0 +1,37 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+dummy_np = types.ModuleType("numpy")
+dummy_np.ndarray = object
+sys.modules.setdefault("numpy", dummy_np)
+dummy_scipy = types.ModuleType("scipy")
+io_mod = types.ModuleType("io")
+wavfile_mod = types.ModuleType("wavfile")
+setattr(wavfile_mod, "write", lambda *a, **k: None)
+io_mod.wavfile = wavfile_mod
+dummy_scipy.io = io_mod
+sys.modules.setdefault("scipy", dummy_scipy)
+sys.modules.setdefault("scipy.io", io_mod)
+sys.modules.setdefault("scipy.io.wavfile", wavfile_mod)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+from inanna_ai.personality_layers.citrinitas_layer import CitrinitasPersonality
+from inanna_ai.personality_layers import REGISTRY
+
+
+def test_citrinitas_methods_and_registry():
+    layer = CitrinitasPersonality()
+    msg = layer.speak("shine")
+    assert "citrinitas" in msg.lower()
+    assert "shine" in msg
+
+    path = layer.choose_path("journey")
+    assert "journey" in path
+
+    assert "citrinitas_layer" in REGISTRY
+    assert REGISTRY["citrinitas_layer"] is CitrinitasPersonality

--- a/tests/test_nigredo_layer.py
+++ b/tests/test_nigredo_layer.py
@@ -1,0 +1,37 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+dummy_np = types.ModuleType("numpy")
+dummy_np.ndarray = object
+sys.modules.setdefault("numpy", dummy_np)
+dummy_scipy = types.ModuleType("scipy")
+io_mod = types.ModuleType("io")
+wavfile_mod = types.ModuleType("wavfile")
+setattr(wavfile_mod, "write", lambda *a, **k: None)
+io_mod.wavfile = wavfile_mod
+dummy_scipy.io = io_mod
+sys.modules.setdefault("scipy", dummy_scipy)
+sys.modules.setdefault("scipy.io", io_mod)
+sys.modules.setdefault("scipy.io.wavfile", wavfile_mod)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+from inanna_ai.personality_layers.nigredo_layer import NigredoPersonality
+from inanna_ai.personality_layers import REGISTRY
+
+
+def test_nigredo_methods_and_registry():
+    layer = NigredoPersonality()
+    msg = layer.speak("hello")
+    assert "nigredo" in msg.lower()
+    assert "hello" in msg
+
+    path = layer.choose_path("abyss")
+    assert "abyss" in path
+
+    assert "nigredo_layer" in REGISTRY
+    assert REGISTRY["nigredo_layer"] is NigredoPersonality

--- a/tests/test_rubedo_layer.py
+++ b/tests/test_rubedo_layer.py
@@ -1,0 +1,37 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+dummy_np = types.ModuleType("numpy")
+dummy_np.ndarray = object
+sys.modules.setdefault("numpy", dummy_np)
+dummy_scipy = types.ModuleType("scipy")
+io_mod = types.ModuleType("io")
+wavfile_mod = types.ModuleType("wavfile")
+setattr(wavfile_mod, "write", lambda *a, **k: None)
+io_mod.wavfile = wavfile_mod
+dummy_scipy.io = io_mod
+sys.modules.setdefault("scipy", dummy_scipy)
+sys.modules.setdefault("scipy.io", io_mod)
+sys.modules.setdefault("scipy.io.wavfile", wavfile_mod)
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+from inanna_ai.personality_layers.rubedo_layer import RubedoPersonality
+from inanna_ai.personality_layers import REGISTRY
+
+
+def test_rubedo_methods_and_registry():
+    layer = RubedoPersonality()
+    msg = layer.speak("rise")
+    assert "rubedo" in msg.lower()
+    assert "rise" in msg
+
+    path = layer.choose_path("path")
+    assert "path" in path
+
+    assert "rubedo_layer" in REGISTRY
+    assert REGISTRY["rubedo_layer"] is RubedoPersonality


### PR DESCRIPTION
## Summary
- add Nigredo, Rubedo and Citrinitas personality layers
- auto-discover module personalities in registry
- test new layers and registry discovery

## Testing
- `pytest tests/test_nigredo_layer.py tests/test_rubedo_layer.py tests/test_citrinitas_layer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68723ac1edcc832ea5750d532b2811b5