### PR TITLE
Add emotion tracking to insights

### DIFF
--- a/insight_matrix.json
+++ b/insight_matrix.json
@@ -1,1 +1,14 @@
-{}
+{
+  "_schema": {
+    "counts": {
+      "total": 0,
+      "success": 0,
+      "tones": {},
+      "emotions": {},
+      "responded_with": {}
+    },
+    "best_tone": "",
+    "action_success_rate": 0.0,
+    "last_updated": ""
+  }
+}

--- a/tests/test_insight_compiler.py
+++ b/tests/test_insight_compiler.py
@@ -13,20 +13,47 @@ def test_update_aggregates(tmp_path, monkeypatch):
     monkeypatch.setattr(ic, "INSIGHT_FILE", insight_file)
 
     logs = [
-        {"intent": "open portal", "tone": "joy", "success": True},
-        {"intent": "open portal", "tone": "joy", "success": False},
+        {
+            "intent": "open portal",
+            "tone": "joy",
+            "emotion": "joy",
+            "responded_with": "text",
+            "success": True,
+        },
+        {
+            "intent": "open portal",
+            "tone": "joy",
+            "emotion": "sad",
+            "responded_with": "voice",
+            "success": False,
+        },
     ]
     ic.update_insights(logs)
     data = json.loads(insight_file.read_text())
     assert data["open portal"]["counts"]["total"] == 2
     assert data["open portal"]["counts"]["success"] == 1
+    assert data["open portal"]["counts"]["emotions"]["joy"]["total"] == 1
+    assert data["open portal"]["counts"]["emotions"]["sad"]["total"] == 1
+    assert data["open portal"]["counts"]["responded_with"]["text"] == 1
+    assert data["open portal"]["counts"]["responded_with"]["voice"] == 1
 
     logs2 = [
-        {"intent": "open portal", "tone": "calm", "success": True},
+        {
+            "intent": "open portal",
+            "tone": "calm",
+            "emotion": "joy",
+            "responded_with": ["text", "music"],
+            "success": True,
+        },
     ]
     ic.update_insights(logs2)
     data = json.loads(insight_file.read_text())
     assert data["open portal"]["counts"]["total"] == 3
     assert data["open portal"]["counts"]["success"] == 2
+    assert data["open portal"]["counts"]["emotions"]["joy"]["total"] == 2
+    assert data["open portal"]["counts"]["emotions"]["joy"]["success"] == 2
+    assert data["open portal"]["counts"]["responded_with"]["text"] == 2
+    assert data["open portal"]["counts"]["responded_with"]["voice"] == 1
+    assert data["open portal"]["counts"]["responded_with"]["music"] == 1
     assert data["open portal"]["best_tone"] == "calm"
     assert abs(data["open portal"]["action_success_rate"] - 2 / 3) < 0.001


### PR DESCRIPTION
## Summary
- track emotions and response modalities when updating insight matrix
- include schema example for new fields
- test recording of emotional metadata

## Testing
- `pytest -q tests/test_insight_compiler.py`

------
https://chatgpt.com/codex/tasks/task_e_68723de938cc832e8ed95127857747e8