### PR TITLE
Integrate voice config into voice synthesis

### DIFF
--- a/inanna_ai/voice_evolution.py
+++ b/inanna_ai/voice_evolution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable
 from pathlib import Path
+import yaml
 
 from . import db_storage
 
@@ -13,6 +14,35 @@ DEFAULT_VOICE_STYLES: Dict[str, Dict[str, float]] = {
     "calm": {"speed": 0.9, "pitch": -1.0},
     "excited": {"speed": 1.1, "pitch": 1.0},
 }
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "voice_config.yaml"
+
+
+def load_voice_config(path: Path = CONFIG_PATH) -> Dict[str, Dict[str, Any]]:
+    """Return archetype settings loaded from ``path`` if it exists."""
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        out: Dict[str, Dict[str, Any]] = {}
+        for key, info in data.items():
+            if isinstance(info, dict):
+                out[key.lower()] = info
+        return out
+    return {}
+
+
+VOICE_CONFIG: Dict[str, Dict[str, Any]] = load_voice_config()
+
+for info in VOICE_CONFIG.values():
+    name = info.get("tone")
+    if name:
+        DEFAULT_VOICE_STYLES.setdefault(
+            name.lower(),
+            {
+                "speed": float(info.get("speed", 1.0)),
+                "pitch": float(info.get("pitch", 0.0)),
+            },
+        )
 
 
 class VoiceEvolution:
@@ -98,4 +128,6 @@ __all__ = [
     "load_profiles",
     "store_profiles",
     "DEFAULT_VOICE_STYLES",
+    "VOICE_CONFIG",
+    "load_voice_config",
 ]

--- a/run_song_demo.py
+++ b/run_song_demo.py
@@ -6,12 +6,25 @@ This script analyzes a local MP3 or WAV file using
 """
 
 import argparse
+from pathlib import Path
+import yaml
 
 from MUSIC_FOUNDATION.inanna_music_COMPOSER_ai import (
     InannaMusicInterpreter,
     export_qnl,
 )
 from MUSIC_FOUNDATION.qnl_utils import generate_qnl_structure
+
+
+CONFIG_PATH = Path(__file__).resolve().parent / "voice_config.yaml"
+
+
+def load_voice_config(path: Path = CONFIG_PATH) -> dict:
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return {k.lower(): v for k, v in data.items() if isinstance(v, dict)}
+    return {}
 
 
 def main() -> None:
@@ -25,6 +38,7 @@ def main() -> None:
     parser.add_argument(
         "--json", default="output/qnl_7plane.json", help="QNL JSON output path"
     )
+    parser.add_argument("--tone", help="Personality tone from voice_config")
     args = parser.parse_args()
 
     engine = InannaMusicInterpreter(args.audio_file)
@@ -33,6 +47,10 @@ def main() -> None:
     planes = engine.analyze_planes()
     engine.export_preview(args.preview)
 
+    voice_cfg = {}
+    if args.tone:
+        voice_cfg = load_voice_config().get(args.tone.lower(), {})
+
     qnl_data = generate_qnl_structure(
         chroma,
         engine.tempo,
@@ -40,6 +58,9 @@ def main() -> None:
         planes=planes,
     )
     export_qnl(qnl_data, args.json)
+
+    if voice_cfg:
+        print("Voice settings:", voice_cfg)
 
     print("QNL Output:")
     for phrase in qnl_data["qnl_output"]:

--- a/tests/test_voice_config.py
+++ b/tests/test_voice_config.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import types
+
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+sys.modules.setdefault("EmotiVoice", types.ModuleType("EmotiVoice"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("openvoice", types.ModuleType("openvoice"))
+sys.modules.setdefault("gtts", types.ModuleType("gtts"))
+
+from inanna_ai import voice_evolution, voice_layer_albedo
+
+
+def test_load_voice_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "voice_config.yaml"
+    cfg.write_text("Sage:\n  pitch: 0.1\n  speed: 1.2\n  tone: lunar\n")
+    importlib.reload(voice_evolution)
+    voice_evolution.VOICE_CONFIG = voice_evolution.load_voice_config(cfg)
+    for info in voice_evolution.VOICE_CONFIG.values():
+        tone = info.get("tone")
+        if tone:
+            voice_evolution.DEFAULT_VOICE_STYLES[tone] = {
+                "speed": float(info.get("speed", 1.0)),
+                "pitch": float(info.get("pitch", 0.0)),
+            }
+    assert voice_evolution.VOICE_CONFIG["sage"]["tone"] == "lunar"
+    assert voice_evolution.DEFAULT_VOICE_STYLES["lunar"]["speed"] == 1.2
+
+
+def test_modulate_voice_uses_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "voice_config.yaml"
+    cfg.write_text("Sage:\n  pitch: 0.2\n  speed: 0.8\n  tone: lunar\n")
+    importlib.reload(voice_evolution)
+    voice_evolution.VOICE_CONFIG = voice_evolution.load_voice_config(cfg)
+    for info in voice_evolution.VOICE_CONFIG.values():
+        tone = info.get("tone")
+        if tone:
+            voice_evolution.DEFAULT_VOICE_STYLES[tone] = {
+                "speed": float(info.get("speed", 1.0)),
+                "pitch": float(info.get("pitch", 0.0)),
+            }
+    monkeypatch.setattr(
+        voice_layer_albedo, "TONE_PRESETS", voice_layer_albedo.TONE_PRESETS.copy()
+    )
+    monkeypatch.setattr(
+        voice_layer_albedo, "voice_evolution", voice_evolution
+    )
+    importlib.reload(voice_layer_albedo)
+
+    called = {}
+
+    def fake_synth(text: str, tone: str):
+        called["args"] = (text, tone)
+        return "x.wav"
+
+    monkeypatch.setattr(voice_layer_albedo.speaking_engine, "synthesize_speech", fake_synth)
+
+    path = voice_layer_albedo.modulate_voice("hi", "sage")
+    assert path == "x.wav"
+    assert called["args"] == ("hi", "lunar")
+    assert voice_evolution.DEFAULT_VOICE_STYLES["lunar"]["pitch"] == 0.2
+

--- a/voice_config.yaml
+++ b/voice_config.yaml
@@ -1,0 +1,28 @@
+Jester:
+  pitch: 0.3
+  speed: 1.1
+  tone: albedo
+Warrior:
+  pitch: 0.2
+  speed: 1.05
+  tone: rubedo
+Orphan:
+  pitch: -0.4
+  speed: 0.9
+  tone: lunar
+Caregiver:
+  pitch: -0.2
+  speed: 0.95
+  tone: nigredo
+Hero:
+  pitch: 0.5
+  speed: 1.2
+  tone: rubedo
+Sage:
+  pitch: -0.1
+  speed: 0.9
+  tone: albedo
+Everyman:
+  pitch: 0.0
+  speed: 1.0
+  tone: calm


### PR DESCRIPTION
## Summary
- add `voice_config.yaml` describing archetype voice presets
- read presets in `voice_evolution` and merge into default styles
- update `voice_layer_albedo` to use the config when modulating voices
- allow `mix_tracks.py` and `run_song_demo.py` to select a tone from the config
- test YAML parsing and integration with the voice layer

## Testing
- `pytest tests/test_voice_config.py -q`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687240b3a508832e9ad078cc2dada477