### PR TITLE
Add emotional state persistence module

### DIFF
--- a/emotional_state.py
+++ b/emotional_state.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+"""Persist and retrieve emotional and soul state parameters."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+STATE_FILE = Path("data/emotion_state.json")
+_DEFAULT_STATE = {
+    "current_layer": None,
+    "last_emotion": None,
+    "resonance_level": 0.0,
+    "preferred_expression_channel": "text",
+    "resonance_pairs": [],
+    "soul_state": None,
+}
+_STATE: Dict[str, Any] = {}
+
+
+def _load_state() -> None:
+    """Load state from :data:`STATE_FILE` into :data:`_STATE`."""
+    global _STATE
+    if STATE_FILE.exists():
+        try:
+            _STATE = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            _STATE = _DEFAULT_STATE.copy()
+    else:
+        _STATE = _DEFAULT_STATE.copy()
+
+
+def _save_state() -> None:
+    """Write :data:`_STATE` to :data:`STATE_FILE`."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(_STATE, indent=2), encoding="utf-8")
+
+
+_load_state()
+
+
+def get_current_layer() -> str | None:
+    """Return the active personality layer name if set."""
+    return _STATE.get("current_layer")
+
+
+def set_current_layer(layer: str | None) -> None:
+    """Set ``layer`` as the active personality layer."""
+    _STATE["current_layer"] = layer
+    _save_state()
+
+
+def get_last_emotion() -> str | None:
+    """Return the most recently observed emotion."""
+    return _STATE.get("last_emotion")
+
+
+def set_last_emotion(emotion: str | None) -> None:
+    """Record ``emotion`` as the last observed emotion."""
+    _STATE["last_emotion"] = emotion
+    _save_state()
+
+
+def get_resonance_level() -> float:
+    """Return the current resonance level."""
+    return float(_STATE.get("resonance_level", 0.0))
+
+
+def set_resonance_level(level: float) -> None:
+    """Set the emotional resonance ``level``."""
+    _STATE["resonance_level"] = float(level)
+    _save_state()
+
+
+def get_preferred_expression_channel() -> str:
+    """Return the preferred expression channel."""
+    return str(_STATE.get("preferred_expression_channel", "text"))
+
+
+def set_preferred_expression_channel(channel: str) -> None:
+    """Persist the preferred expression ``channel``."""
+    _STATE["preferred_expression_channel"] = channel
+    _save_state()
+
+
+def get_resonance_pairs() -> List[Tuple[float, float]]:
+    """Return stored resonance frequency pairs."""
+    pairs = _STATE.get("resonance_pairs", [])
+    return [(float(a), float(b)) for a, b in pairs]
+
+
+def set_resonance_pairs(pairs: List[Tuple[float, float]]) -> None:
+    """Persist ``pairs`` of resonance frequencies."""
+    _STATE["resonance_pairs"] = [[float(a), float(b)] for a, b in pairs]
+    _save_state()
+
+
+def get_soul_state() -> str | None:
+    """Return the current soul state."""
+    return _STATE.get("soul_state")
+
+
+def set_soul_state(state: str | None) -> None:
+    """Persist the current ``state`` of the soul."""
+    _STATE["soul_state"] = state
+    _save_state()
+
+
+__all__ = [
+    "get_current_layer",
+    "set_current_layer",
+    "get_last_emotion",
+    "set_last_emotion",
+    "get_resonance_level",
+    "set_resonance_level",
+    "get_preferred_expression_channel",
+    "set_preferred_expression_channel",
+    "get_resonance_pairs",
+    "set_resonance_pairs",
+    "get_soul_state",
+    "set_soul_state",
+]

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -24,7 +24,7 @@ from inanna_ai import response_manager, tts_coqui, emotion_analysis, db_storage
 from inanna_ai.personality_layers import AlbedoPersonality, REGISTRY as PERSONALITY_REGISTRY
 from inanna_ai import voice_layer_albedo
 from SPIRAL_OS import qnl_engine, symbolic_parser
-import emotion_registry
+import emotional_state
 import training_guide
 from corpus_memory_logging import log_interaction, load_interactions
 from insight_compiler import update_insights, load_insights
@@ -142,7 +142,7 @@ class MoGEOrchestrator:
             tone = qnl_data.get("tone")
             intents = symbolic_parser.parse_intent(qnl_data)
 
-        layer_name = emotion_registry.get_current_layer()
+        layer_name = emotional_state.get_current_layer()
         if layer_name:
             layer_cls = PERSONALITY_REGISTRY.get(layer_name)
             if layer_cls is not None and not isinstance(self._albedo, layer_cls):
@@ -240,8 +240,8 @@ class MoGEOrchestrator:
         emotion = qnl_data.get("tone", "neutral")
         self._update_mood(emotion)
         dominant = max(self.mood_state, key=self.mood_state.get)
-        emotion_registry.set_last_emotion(dominant)
-        emotion_registry.set_resonance_level(self.mood_state[dominant])
+        emotional_state.set_last_emotion(dominant)
+        emotional_state.set_resonance_level(self.mood_state[dominant])
 
         emotion_data = {
             "emotion": dominant,
@@ -250,7 +250,7 @@ class MoGEOrchestrator:
         }
         result = self.route(text, emotion_data, qnl_data=qnl_data)
         if self._active_layer_name:
-            emotion_registry.set_current_layer(self._active_layer_name)
+            emotional_state.set_current_layer(self._active_layer_name)
         return result
 
 

--- a/tests/test_emotional_state.py
+++ b/tests/test_emotional_state.py
@@ -1,0 +1,28 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import emotional_state
+
+
+def test_state_persistence(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(emotional_state, "STATE_FILE", state_file)
+    emotional_state._STATE.clear()
+    emotional_state._save_state()
+
+    pairs = [(440.0, 880.0), (333.0, 666.0)]
+    emotional_state.set_resonance_pairs(pairs)
+    emotional_state.set_soul_state("awakened")
+
+    data = json.loads(state_file.read_text())
+    assert data["resonance_pairs"] == [[440.0, 880.0], [333.0, 666.0]]
+    assert data["soul_state"] == "awakened"
+
+    emotional_state._STATE.clear()
+    emotional_state._load_state()
+    assert emotional_state.get_resonance_pairs() == pairs
+    assert emotional_state.get_soul_state() == "awakened"

--- a/tests/test_orchestrator_handle.py
+++ b/tests/test_orchestrator_handle.py
@@ -83,9 +83,9 @@ def test_dynamic_layer_selection(monkeypatch):
 
     # Patch registry and emotion state
     monkeypatch.setattr(orchestrator, "PERSONALITY_REGISTRY", {"dummy": DummyLayer})
-    monkeypatch.setattr(orchestrator.emotion_registry, "get_current_layer", lambda: "dummy")
+    monkeypatch.setattr(orchestrator.emotional_state, "get_current_layer", lambda: "dummy")
     recorded = {}
-    monkeypatch.setattr(orchestrator.emotion_registry, "set_current_layer", lambda name: recorded.setdefault("layer", name))
+    monkeypatch.setattr(orchestrator.emotional_state, "set_current_layer", lambda name: recorded.setdefault("layer", name))
 
     # Stub heavy components
     monkeypatch.setattr(orchestrator.qnl_engine, "parse_input", lambda t: {"tone": "neutral"})


### PR DESCRIPTION
## Summary
- implement emotional_state module for storing soul state
- switch orchestrator to use emotional_state
- update dynamic layer test accordingly
- add tests for emotional_state persistence

## Testing
- `pytest tests/test_emotional_state.py tests/test_orchestrator_handle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68724f981ee0832eaadd23db480fb331