### PR TITLE
Track glyph resonance metrics

### DIFF
--- a/insight_matrix.json
+++ b/insight_matrix.json
@@ -7,6 +7,7 @@
       "emotions": {},
       "responded_with": {}
     },
+    "resonance_index": {},
     "best_tone": "",
     "action_success_rate": 0.0,
     "last_updated": ""

--- a/tests/test_insight_compiler.py
+++ b/tests/test_insight_compiler.py
@@ -57,3 +57,24 @@ def test_update_aggregates(tmp_path, monkeypatch):
     assert data["open portal"]["counts"]["responded_with"]["music"] == 1
     assert data["open portal"]["best_tone"] == "calm"
     assert abs(data["open portal"]["action_success_rate"] - 2 / 3) < 0.001
+
+
+def test_resonance_index_increases(tmp_path, monkeypatch):
+    insight_file = tmp_path / "insights.json"
+    monkeypatch.setattr(ic, "INSIGHT_FILE", insight_file)
+
+    log = {
+        "intent": "conjure fire",
+        "tone": "joy",
+        "emotion": "joy",
+        "text": "ignite \U0001F702",
+        "success": True,
+    }
+
+    ic.update_insights([log])
+    data = json.loads(insight_file.read_text())
+    assert data["conjure fire"]["resonance_index"]["joy"] == 1
+
+    ic.update_insights([log])
+    data = json.loads(insight_file.read_text())
+    assert data["conjure fire"]["resonance_index"]["joy"] == 2


### PR DESCRIPTION
## Summary
- add glyph mapping and resonance index tracking to `insight_compiler`
- update insight schema with `resonance_index`
- test resonance index accumulation

## Testing
- `pytest tests/test_insight_compiler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872514efe7c832eb3e8a12c4c6cf779