### PR TITLE
Add ritual classification support

### DIFF
--- a/ritual_profile.json
+++ b/ritual_profile.json
@@ -1,0 +1,10 @@
+{
+  "☉": {
+    "joy": ["open portal", "weave sound"],
+    "sadness": ["invoke remembrance"]
+  },
+  "☾": {
+    "calm": ["merge forms"],
+    "anger": ["conjure fire"]
+  }
+}

--- a/task_profiling.py
+++ b/task_profiling.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 """Simple heuristics for classifying input text."""
 
 INSTRUCTION_KEYWORDS = {
@@ -36,10 +39,29 @@ TECHNICAL_KEYWORDS = {
     "code",
 }
 
+_RITUAL_FILE = Path(__file__).resolve().parent / "ritual_profile.json"
+try:
+    _RITUAL_PROFILE: dict[str, dict[str, list[str]]] = json.loads(
+        _RITUAL_FILE.read_text(encoding="utf-8")
+    )
+except Exception:  # pragma: no cover - missing file
+    _RITUAL_PROFILE = {}
 
-def classify_task(text: str) -> str:
-    """Return a coarse category for ``text``."""
-    lowered = text.lower()
+
+def ritual_action_sequence(condition: str, emotion: str) -> list[str]:
+    """Return ritual actions for ``condition`` and ``emotion``."""
+    info = _RITUAL_PROFILE.get(condition, {})
+    return list(info.get(emotion, []))
+
+
+def classify_task(text: str | dict) -> str:
+    """Return a coarse category for ``text`` or data dict."""
+    if isinstance(text, dict):
+        if "ritual_condition" in text or "emotion_trigger" in text:
+            return "ritual"
+        lowered = str(text.get("text", "")).lower()
+    else:
+        lowered = str(text).lower()
     if any(k in lowered for k in INSTRUCTION_KEYWORDS):
         return "instructional"
     if any(k in lowered for k in EMOTIONAL_KEYWORDS):
@@ -49,4 +71,4 @@ def classify_task(text: str) -> str:
     return "technical"
 
 
-__all__ = ["classify_task"]
+__all__ = ["classify_task", "ritual_action_sequence"]

--- a/tests/test_task_profiling.py
+++ b/tests/test_task_profiling.py
@@ -4,7 +4,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from task_profiling import classify_task
+from task_profiling import classify_task, ritual_action_sequence
 
 
 def test_classify_task_basic():
@@ -12,3 +12,12 @@ def test_classify_task_basic():
     assert classify_task("I feel sad") == "emotional"
     assert classify_task("what is the meaning of life?") == "philosophical"
     assert classify_task("import numpy as np") == "technical"
+
+
+def test_classify_task_ritual_dict():
+    assert classify_task({"ritual_condition": "☉", "emotion_trigger": "joy"}) == "ritual"
+
+
+def test_ritual_action_sequence():
+    seq = ritual_action_sequence("☉", "joy")
+    assert seq == ["open portal", "weave sound"]


### PR DESCRIPTION
## Summary
- create `ritual_profile.json` mapping glyphs and emotions to action sequences
- extend `task_profiling.classify_task` to recognize ritual data
- expose `ritual_action_sequence` helper
- test ritual classification and action resolution

## Testing
- `pytest -q tests/test_task_profiling.py`

------
https://chatgpt.com/codex/tasks/task_e_6872530b96d4832e9cce0666fdc19c53