### PR TITLE
Add invocation engine module

### DIFF
--- a/invocation_engine.py
+++ b/invocation_engine.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Pattern-based invocation engine."""
+
+from typing import Callable, Dict, Tuple, Any, List
+import re
+
+import vector_memory
+from orchestrator import MoGEOrchestrator
+
+
+# Map of (symbols, emotion) -> callback
+_CALLBACKS: Dict[Tuple[str, str | None], Callable[[str, str | None, MoGEOrchestrator | None], Any]] = {}
+# Map of (symbols, emotion) -> orchestrator hook name
+_HOOKS: Dict[Tuple[str, str | None], str] = {}
+
+_SYMBOL_RE = re.compile(r"[^\w\s\[\]#]+")
+_EMO_RE = re.compile(r"\[(\w+)\]|#(\w+)")
+
+
+def register_invocation(
+    symbols: str,
+    emotion: str | None = None,
+    callback: Callable[[str, str | None, MoGEOrchestrator | None], Any] | None = None,
+    *,
+    hook: str | None = None,
+) -> None:
+    """Register an invocation pattern with ``callback`` or orchestrator ``hook``."""
+    if callback is None and hook is None:
+        raise ValueError("callback or hook required")
+    key = (symbols, emotion)
+    if callback:
+        _CALLBACKS[key] = callback
+    if hook:
+        _HOOKS[key] = hook
+    try:
+        vector_memory.add_vector(symbols, {"symbols": symbols, "emotion": emotion or ""})
+    except Exception:
+        pass
+
+
+def clear_registry() -> None:
+    """Remove all registered invocation patterns."""
+    _CALLBACKS.clear()
+    _HOOKS.clear()
+
+
+def _extract_symbols(text: str) -> str:
+    parts = _SYMBOL_RE.findall(text)
+    return "".join(parts)
+
+
+def _extract_emotion(text: str) -> str | None:
+    m = _EMO_RE.search(text)
+    if m:
+        return (m.group(1) or m.group(2)).lower()
+    return None
+
+
+def invoke(text: str, orchestrator: MoGEOrchestrator | None = None) -> List[Any]:
+    """Process ``text`` and trigger callbacks for matching invocations."""
+    symbols = _extract_symbols(text)
+    emotion = _extract_emotion(text)
+    key = (symbols, emotion)
+    results: List[Any] = []
+
+    cb = _CALLBACKS.get(key)
+    hk = _HOOKS.get(key)
+
+    if cb is None and hk is None:
+        try:
+            search_res = vector_memory.search(symbols or text, filter={"emotion": emotion} if emotion else None, k=1)
+        except Exception:
+            search_res = []
+        if search_res:
+            meta = search_res[0]
+            key = (str(meta.get("symbols", meta.get("text", ""))), meta.get("emotion") or None)
+            cb = _CALLBACKS.get(key)
+            hk = _HOOKS.get(key)
+
+    if cb:
+        results.append(cb(symbols, emotion, orchestrator))
+    if hk and orchestrator is not None:
+        method = getattr(orchestrator, hk, None)
+        if callable(method):
+            results.append(method(symbols, emotion))
+    return results
+
+
+__all__ = ["register_invocation", "invoke", "clear_registry"]
+

--- a/tests/test_invocation_engine.py
+++ b/tests/test_invocation_engine.py
@@ -1,0 +1,79 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy orchestrator dependencies before importing module
+stub_orch = types.ModuleType("orchestrator")
+class StubMoGE:
+    def __init__(self):
+        pass
+stub_orch.MoGEOrchestrator = StubMoGE
+sys.modules.setdefault("orchestrator", stub_orch)
+
+import invocation_engine
+
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.calls = []
+
+    def mystic(self, symbols, emotion):
+        self.calls.append((symbols, emotion))
+        return {"hook": symbols}
+
+
+def test_known_invocation(monkeypatch):
+    monkeypatch.setattr(invocation_engine.vector_memory, "add_vector", lambda *a, **k: None)
+    invocation_engine.clear_registry()
+
+    called = []
+
+    def cb(sym, emo, orch):
+        called.append((sym, emo))
+        return "ok"
+
+    invocation_engine.register_invocation("∴⟐+🜂", "joy", cb)
+
+    res = invocation_engine.invoke("∴⟐ + 🜂 [joy]")
+
+    assert res == ["ok"]
+    assert called == [("∴⟐+🜂", "joy")]
+
+
+def test_fuzzy_invocation(monkeypatch):
+    invocation_engine.clear_registry()
+    monkeypatch.setattr(invocation_engine.vector_memory, "add_vector", lambda *a, **k: None)
+
+    called = []
+
+    def cb(sym, emo, orch):
+        called.append((sym, emo))
+        return "ok"
+
+    invocation_engine.register_invocation("∴⟐+🜂", "joy", cb)
+
+    def fake_search(query, filter=None, k=1):
+        return [{"symbols": "∴⟐+🜂", "emotion": "joy"}]
+
+    monkeypatch.setattr(invocation_engine.vector_memory, "search", fake_search)
+
+    res = invocation_engine.invoke("∴⟐ + 🜄 [joy]")
+
+    assert res == ["ok"]
+    assert called == [("∴⟐+🜄", "joy")]
+
+
+def test_orchestrator_hook(monkeypatch):
+    invocation_engine.clear_registry()
+    monkeypatch.setattr(invocation_engine.vector_memory, "add_vector", lambda *a, **k: None)
+
+    orch = DummyOrchestrator()
+    invocation_engine.register_invocation("∞", None, hook="mystic")
+
+    res = invocation_engine.invoke("∞", orch)
+
+    assert res == [{"hook": "∞"}]
+    assert orch.calls == [("∞", None)]


### PR DESCRIPTION
## Summary
- create `invocation_engine.py` for symbol & emotion pattern matching
- register callbacks and orchestrator hooks for invocations
- use `vector_memory.search` when direct match isn't found
- add tests for ritual invocation, fuzzy matching and orchestrator hook

## Testing
- `pytest tests/test_invocation_engine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opensmile')*

------
https://chatgpt.com/codex/tasks/task_e_68725789de14832ebc25d8e681e8e975