### PR TITLE
Add ritual invocation logic

### DIFF
--- a/invocation_engine.py
+++ b/invocation_engine.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 """Pattern-based invocation engine."""
 
-from typing import Callable, Dict, Tuple, Any, List
+from typing import Callable, Dict, Tuple, Any, List, TYPE_CHECKING
 import re
 
 import vector_memory
-from orchestrator import MoGEOrchestrator
+
+if TYPE_CHECKING:  # pragma: no cover - avoid circular import at runtime
+    from orchestrator import MoGEOrchestrator
 
 
 # Map of (symbols, emotion) -> callback


### PR DESCRIPTION
## Summary
- add TYPE_CHECKING guard in `invocation_engine` to avoid circular import
- instantiate invocation engine in orchestrator
- after updating mood, check ritual triggers and run actions
- update orchestration tests with module stubs
- test invocation task sequence

## Testing
- `pytest -q tests/test_orchestrator.py::test_route_text_only tests/test_orchestrator.py::test_route_voice tests/test_orchestrator.py::test_route_music tests/test_orchestrator.py::test_route_qnl_voice tests/test_orchestrator.py::test_route_with_albedo_layer tests/test_orchestrator.py::test_context_model_selection tests/test_orchestrator.py::test_handle_input_parses_and_routes tests/test_orchestrator.py::test_schedule_action_executes tests/test_orchestrator_handle.py::test_handle_input_updates_mood tests/test_orchestrator_handle.py::test_route_logs_interaction tests/test_orchestrator_handle.py::test_dynamic_layer_selection tests/test_orchestrator_handle.py::test_invocation_task_sequence -q`

------
https://chatgpt.com/codex/tasks/task_e_68725a0baeac832eba4f201279fd9a0d