### PR TITLE
Refactor music composer imports

### DIFF
--- a/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
+++ b/MUSIC_FOUNDATION/README_INANNA_MUSIC.md
@@ -71,7 +71,7 @@ Receives musical features and transforms them into:
 ✨ Unified agent that performs full ritual:
 
 ```bash
-python3 inanna_music_COMPOSER_ai.py song.mp3
+python -m MUSIC_FOUNDATION.inanna_music_COMPOSER_ai song.mp3
 ```
 
 Produces:

--- a/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
+++ b/MUSIC_FOUNDATION/inanna_music_COMPOSER_ai.py
@@ -11,7 +11,7 @@ This script performs:
 3. Export of preview WAV and structured QNL JSON output
 
 Usage:
-    python3 inanna_music_COMPOSER_ai.py path/to/song.mp3
+    python -m MUSIC_FOUNDATION.inanna_music_COMPOSER_ai path/to/song.mp3
 
 Dependencies:
     pip install librosa soundfile numpy scipy
@@ -23,7 +23,7 @@ import soundfile as sf
 import os
 import json
 
-from .qnl_utils import chroma_to_qnl, generate_qnl_structure
+from MUSIC_FOUNDATION.qnl_utils import chroma_to_qnl, generate_qnl_structure
 
 # -------------------------------
 # QNL GLYPH & EMOTION MAPPINGS
@@ -89,6 +89,12 @@ class InannaMusicInterpreter:
 # -------------------------------
 
 if __name__ == "__main__":
+    if __package__ is None:
+        from pathlib import Path
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
     import argparse
 
     parser = argparse.ArgumentParser(description="INANNA_AI — Sonic Ritual QNL Engine")

--- a/tests/test_inanna_music_cli.py
+++ b/tests/test_inanna_music_cli.py
@@ -1,0 +1,30 @@
+import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tests.data.short_wav_base64 import SHORT_WAV_BASE64
+
+
+def test_inanna_music_cli(tmp_path):
+    audio = tmp_path / "short.wav"
+    audio.write_bytes(base64.b64decode(SHORT_WAV_BASE64))
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+
+    result = subprocess.run(
+        ["python", "-m", "MUSIC_FOUNDATION.inanna_music_COMPOSER_ai", str(audio)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert (tmp_path / "output" / "preview.wav").exists()
+    assert (tmp_path / "output" / "qnl_song.json").exists()


### PR DESCRIPTION
## Summary
- use absolute imports in `inanna_music_COMPOSER_ai.py`
- update CLI instructions in music foundation README
- inject parent folder into `sys.path` when executed directly
- add regression test for module CLI

## Testing
- `pytest tests/test_inanna_music_cli.py::test_inanna_music_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_68726378c610832ea740d4a329d65c05