### PR TITLE
Link emotion state to music parameters

### DIFF
--- a/emotion_music_map.yaml
+++ b/emotion_music_map.yaml
@@ -1,0 +1,16 @@
+joy:
+  tempo: 140
+  scale: C_major
+  rhythm: syncopated
+sadness:
+  tempo: 70
+  scale: A_minor
+  rhythm: slow
+anger:
+  tempo: 150
+  scale: D_minor
+  rhythm: aggressive
+neutral:
+  tempo: 100
+  scale: C_major
+  rhythm: steady

--- a/tests/test_emotion_music_map.py
+++ b/tests/test_emotion_music_map.py
@@ -1,0 +1,25 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+dummy_yaml = types.ModuleType("yaml")
+dummy_yaml.safe_load = lambda s: {}
+sys.modules.setdefault("yaml", dummy_yaml)
+
+from MUSIC_FOUNDATION import inanna_music_COMPOSER_ai as composer
+
+
+def test_get_emotion_music_params(monkeypatch):
+    mapping = {"joy": {"tempo": 150, "scale": "C_major", "rhythm": "swing"}}
+    monkeypatch.setattr(composer.emotional_state, "get_last_emotion", lambda: "joy")
+
+    tempo, scale, melody, rhythm = composer.get_emotion_music_params(120, mapping)
+    assert tempo == 150
+    assert scale == "C_major"
+    assert rhythm == "swing"
+    assert melody == composer.SCALE_MELODIES["C_major"]


### PR DESCRIPTION
## Summary
- configure emotion-based music parameters via `emotion_music_map.yaml`
- adapt `inanna_music_COMPOSER_ai` to read emotion state and apply mapping
- generate melody tracks reflecting the active emotion
- add tests covering emotion-driven parameter selection

## Testing
- `pytest tests/test_emotion_music_map.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68726728cf84832ebf1056ac141fc32f