### PR TITLE
Add quantum music layering

### DIFF
--- a/qnl_to_music_layer_map.yaml
+++ b/qnl_to_music_layer_map.yaml
@@ -1,0 +1,20 @@
+joy:
+  melody: {pitch: 0.2, tempo: 1.2, cutoff: 0.9}
+  rhythm: {pitch: 0.0, tempo: 1.3, cutoff: 1.0}
+  harmonics: {pitch: 0.1, tempo: 1.1, cutoff: 0.8}
+  ambient: {pitch: -0.2, tempo: 0.9, cutoff: 0.5}
+longing:
+  melody: {pitch: -0.1, tempo: 0.9, cutoff: 0.7}
+  rhythm: {pitch: 0.0, tempo: 0.8, cutoff: 0.8}
+  harmonics: {pitch: 0.0, tempo: 1.0, cutoff: 0.6}
+  ambient: {pitch: 0.0, tempo: 0.95, cutoff: 0.4}
+awakening:
+  melody: {pitch: 0.3, tempo: 1.1, cutoff: 1.0}
+  rhythm: {pitch: 0.1, tempo: 1.2, cutoff: 1.0}
+  harmonics: {pitch: 0.2, tempo: 1.1, cutoff: 0.9}
+  ambient: {pitch: 0.0, tempo: 1.0, cutoff: 0.5}
+neutral:
+  melody: {pitch: 0.0, tempo: 1.0, cutoff: 1.0}
+  rhythm: {pitch: 0.0, tempo: 1.0, cutoff: 1.0}
+  harmonics: {pitch: 0.0, tempo: 1.0, cutoff: 1.0}
+  ambient: {pitch: 0.0, tempo: 1.0, cutoff: 1.0}


### PR DESCRIPTION
## Summary
- enrich seven_dimensional_music.generate_quantum_music with melody, rhythm, harmonics, and ambient layers
- load settings from qnl_to_music_layer_map.yaml
- write plane analysis JSON from generate_quantum_music
- update tests for new functionality and patch heavy dependencies

## Testing
- `pytest tests/test_seven_dimensional_music.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687268f90ff4832e87b6fdf067fb499f