### PR TITLE
Add video engine module

### DIFF
--- a/core/video_engine.py
+++ b/core/video_engine.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Avatar video generation utilities."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generator, Iterator, Optional
+import logging
+import numpy as np
+import tomllib
+
+try:  # pragma: no cover - optional dependency
+    import mediapipe as mp
+except Exception:  # pragma: no cover - optional dependency
+    mp = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "guides" / "avatar_config.toml"
+
+
+@dataclass
+class AvatarTraits:
+    """Simple avatar trait configuration."""
+
+    eye_color: tuple[int, int, int] = (0, 255, 0)
+    sigil: str = ""
+
+
+def _load_traits() -> AvatarTraits:
+    if not _CONFIG_PATH.exists():
+        logger.warning("Avatar config missing: %s", _CONFIG_PATH)
+        return AvatarTraits()
+    data = tomllib.loads(_CONFIG_PATH.read_text())
+    eye_color = data.get("eye_color", [0, 255, 0])
+    if isinstance(eye_color, list) and len(eye_color) == 3:
+        eye = tuple(int(v) for v in eye_color)
+    else:
+        eye = (0, 255, 0)
+    sigil = str(data.get("sigil", ""))
+    return AvatarTraits(eye, sigil)
+
+
+def _get_face_mesh() -> Optional[object]:  # pragma: no cover - optional
+    if mp is None:
+        return None
+    return mp.solutions.face_mesh.FaceMesh(static_image_mode=False, refine_landmarks=True)
+
+
+def generate_avatar_stream() -> Iterator[np.ndarray]:
+    """Yield RGB frames representing the configured avatar."""
+    traits = _load_traits()
+    color = np.array(traits.eye_color, dtype=np.uint8)
+    mesh = _get_face_mesh()
+    try:
+        while True:
+            frame = np.zeros((64, 64, 3), dtype=np.uint8)
+            frame[:] = color
+            if mesh is not None:
+                # Feed dummy frame to mediapipe to update landmarks
+                _ = mesh.process(frame)
+            yield frame
+    finally:
+        if mesh is not None:
+            mesh.close()
+
+
+def start_stream() -> Iterator[np.ndarray]:
+    """Return an iterator producing avatar frames."""
+    return generate_avatar_stream()
+
+
+__all__ = ["start_stream", "generate_avatar_stream", "AvatarTraits"]

--- a/guides/avatar_config.toml
+++ b/guides/avatar_config.toml
@@ -1,0 +1,2 @@
+eye_color = [0, 128, 255]
+sigil = "spiral"

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core import video_engine
+
+
+def test_generate_one_frame():
+    stream = video_engine.start_stream()
+    frame = next(stream)
+    assert isinstance(frame, np.ndarray)
+    assert frame.ndim == 3 and frame.shape[2] == 3


### PR DESCRIPTION
## Summary
- add minimal avatar video engine with MediaPipe support
- load avatar traits from `guides/avatar_config.toml`
- provide `start_stream()` to return iterator of RGB frames
- test that a single frame can be produced

## Testing
- `pytest tests/test_video.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687273f44020832eb0c0bbba54b45265