### PR TITLE
Add communication connectors

### DIFF
--- a/guides/commands.json
+++ b/guides/commands.json
@@ -1,0 +1,5 @@
+{
+  "greet": "hello",
+  "farewell": "goodbye",
+  "start music": "play_music"
+}

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,0 +1,79 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools import connector
+
+
+def _dummy_settings(backend: str) -> dict:
+    return {
+        "backend": backend,
+        "webrtc_server": "x",
+        "discord_token": "y",
+        "telegram_token": "z",
+        "latency": 0.0,
+    }
+
+
+def test_start_call_webrtc(monkeypatch):
+    calls = {}
+
+    class Dummy:
+        def __init__(self, server: str, latency: float = 0.0):
+            calls["args"] = (server, latency)
+
+        def start(self, audio, video):
+            calls["started"] = True
+
+    monkeypatch.setattr(connector, "WebRTCConnector", Dummy)
+    monkeypatch.setattr(connector, "load_settings", lambda: _dummy_settings("webrtc"))
+
+    audio = iter([b"a"])
+    video = iter([b"v"])
+    obj = connector.start_call(audio, video)
+
+    assert calls["args"] == ("x", 0.0)
+    assert calls["started"] is True
+    assert isinstance(obj, Dummy)
+
+
+def test_start_call_discord(monkeypatch):
+    calls = {}
+
+    class Dummy:
+        def __init__(self, token: str, latency: float = 0.0):
+            calls["args"] = (token, latency)
+
+        def start(self, audio, video):
+            calls["started"] = True
+
+    monkeypatch.setattr(connector, "DiscordConnector", Dummy)
+    monkeypatch.setattr(connector, "load_settings", lambda: _dummy_settings("discord"))
+
+    obj = connector.start_call(iter([]), iter([]))
+
+    assert calls["args"] == ("y", 0.0)
+    assert calls["started"] is True
+    assert isinstance(obj, Dummy)
+
+
+def test_start_call_telegram(monkeypatch):
+    calls = {}
+
+    class Dummy:
+        def __init__(self, token: str, latency: float = 0.0):
+            calls["args"] = (token, latency)
+
+        def start(self, audio, video):
+            calls["started"] = True
+
+    monkeypatch.setattr(connector, "TelegramConnector", Dummy)
+    monkeypatch.setattr(connector, "load_settings", lambda: _dummy_settings("telegram"))
+
+    obj = connector.start_call(iter([]), iter([]))
+
+    assert calls["args"] == ("z", 0.0)
+    assert calls["started"] is True
+    assert isinstance(obj, Dummy)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility connectors for communication."""
+
+from .connector import start_call, WebRTCConnector, DiscordConnector, TelegramConnector
+
+__all__ = ["start_call", "WebRTCConnector", "DiscordConnector", "TelegramConnector"]

--- a/tools/connector.py
+++ b/tools/connector.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""Simple communication connectors for SPIRAL_OS."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Any
+import json
+import logging
+
+try:  # pragma: no cover - optional dependency
+    from aiortc import RTCPeerConnection  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    RTCPeerConnection = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import discord  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    discord = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from telegram import Bot  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Bot = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILE = Path(__file__).resolve().parent / "settings.json"
+
+_DEFAULT_SETTINGS = {
+    "backend": "webrtc",
+    "webrtc_server": "wss://example.com/signaling",
+    "discord_token": "",
+    "telegram_token": "",
+    "latency": 0.1,
+}
+
+
+def load_settings() -> dict:
+    """Return connector settings."""
+    if CONFIG_FILE.exists():
+        return json.loads(CONFIG_FILE.read_text())
+    return _DEFAULT_SETTINGS.copy()
+
+
+@dataclass
+class WebRTCConnector:
+    """Connector for WebRTC communication."""
+
+    server: str
+    latency: float = 0.0
+
+    def start(self, audio: Iterator[Any], video: Iterator[Any]) -> None:
+        """Start a WebRTC call."""
+        if RTCPeerConnection is None:  # pragma: no cover - optional dependency
+            logger.warning("aiortc not installed")
+            return
+        # Real implementation would create peer connection and stream tracks
+        logger.info("Starting WebRTC call to %s", self.server)
+        for _ in audio:
+            pass  # placeholder
+
+
+@dataclass
+class DiscordConnector:
+    """Connector for Discord voice chat."""
+
+    token: str
+    latency: float = 0.0
+
+    def start(self, audio: Iterator[Any], video: Iterator[Any]) -> None:
+        """Start a Discord call."""
+        if discord is None:  # pragma: no cover - optional dependency
+            logger.warning("discord.py not installed")
+            return
+        logger.info("Starting Discord call")
+        for _ in audio:
+            pass  # placeholder
+
+
+@dataclass
+class TelegramConnector:
+    """Connector for Telegram voice chat."""
+
+    token: str
+    latency: float = 0.0
+
+    def start(self, audio: Iterator[Any], video: Iterator[Any]) -> None:
+        """Start a Telegram call."""
+        if Bot is None:  # pragma: no cover - optional dependency
+            logger.warning("python-telegram-bot not installed")
+            return
+        logger.info("Starting Telegram call")
+        for _ in audio:
+            pass  # placeholder
+
+
+def start_call(audio: Iterator[Any], video: Iterator[Any], backend: str | None = None) -> Any:
+    """Dispatch call to the configured backend."""
+    settings = load_settings()
+    backend = backend or settings.get("backend", "webrtc")
+    latency = settings.get("latency", 0.0)
+
+    if backend == "webrtc":
+        conn = WebRTCConnector(settings.get("webrtc_server", ""), latency)
+    elif backend == "discord":
+        conn = DiscordConnector(settings.get("discord_token", ""), latency)
+    elif backend == "telegram":
+        conn = TelegramConnector(settings.get("telegram_token", ""), latency)
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+    conn.start(audio, video)
+    return conn
+
+
+__all__ = [
+    "start_call",
+    "load_settings",
+    "WebRTCConnector",
+    "DiscordConnector",
+    "TelegramConnector",
+]

--- a/tools/settings.json
+++ b/tools/settings.json
@@ -1,0 +1,7 @@
+{
+  "backend": "webrtc",
+  "webrtc_server": "wss://example.com/signaling",
+  "discord_token": "YOUR_DISCORD_TOKEN",
+  "telegram_token": "YOUR_TELEGRAM_TOKEN",
+  "latency": 0.1
+}


### PR DESCRIPTION
## Summary
- add tools.connector with connectors for WebRTC, Discord and Telegram
- store settings in tools/settings.json
- list example command mappings
- provide tests for dispatching start_call

## Testing
- `pytest tests/test_communication.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68727523fc1c832eab69038f94b40962