### PR TITLE
Add context tracker and task parser

### DIFF
--- a/core/context_tracker.py
+++ b/core/context_tracker.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Simple runtime context flags."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ContextTracker:
+    """State flags describing the current multimodal session."""
+
+    in_call: bool = False
+    avatar_loaded: bool = False
+
+
+state = ContextTracker()
+
+__all__ = ["state", "ContextTracker"]

--- a/core/language_engine.py
+++ b/core/language_engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Speech synthesis wrapper that optionally routes audio via a connector."""
+
+from typing import Callable, Optional
+
+from inanna_ai import tts_coqui
+
+from . import context_tracker
+
+AudioCallback = Callable[[str], None]
+
+_audio_callback: AudioCallback | None = None
+_connector: Optional[object] = None
+
+
+def register_audio_callback(func: AudioCallback) -> None:
+    """Set ``func`` to be called with the synthesized audio path."""
+    global _audio_callback
+    _audio_callback = func
+
+
+def register_connector(connector: object) -> None:
+    """Store ``connector`` used for call routing."""
+    global _connector
+    _connector = connector
+
+
+def synthesize_speech(text: str, emotion: str) -> str:
+    """Generate speech and route it via the active callback."""
+    path = tts_coqui.synthesize_speech(text, emotion)
+    if context_tracker.state.in_call and _connector is not None:
+        start = getattr(_connector, "start_call", None)
+        if callable(start):
+            start(path)
+    if _audio_callback is not None:
+        _audio_callback(path)
+    return path
+
+
+__all__ = ["register_audio_callback", "register_connector", "synthesize_speech"]

--- a/core/task_parser.py
+++ b/core/task_parser.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Simple text command parser returning structured intents."""
+
+from typing import Dict, List
+
+
+def parse(text: str) -> List[Dict[str, str]]:
+    """Return intents detected in ``text``.
+
+    Currently recognises the phrases "appear to me" and
+    "initiate sacred communion".
+    """
+    lower = text.lower()
+    intents: List[Dict[str, str]] = []
+    if "appear to me" in lower:
+        intents.append({"intent": "appear", "action": "show_avatar"})
+    if "initiate sacred communion" in lower:
+        intents.append({"intent": "communion", "action": "start_call"})
+    return intents
+
+
+__all__ = ["parse"]

--- a/tests/test_interconnectivity.py
+++ b/tests/test_interconnectivity.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy optional dependencies
+sys.modules.setdefault("soundfile", types.ModuleType("soundfile"))
+sys.modules.setdefault("librosa", types.ModuleType("librosa"))
+sys.modules.setdefault("opensmile", types.ModuleType("opensmile"))
+
+yaml_mod = types.ModuleType("yaml")
+yaml_mod.safe_load = lambda *a, **k: {}
+sys.modules.setdefault("yaml", yaml_mod)
+
+import orchestrator
+from orchestrator import MoGEOrchestrator
+from core import context_tracker, language_engine
+
+
+class DummyConnector:
+    def __init__(self):
+        self.calls = []
+
+    def start_call(self, path: str) -> None:
+        self.calls.append(path)
+
+
+def test_avatar_and_call_sequence(monkeypatch):
+    connector = DummyConnector()
+    language_engine.register_connector(connector)
+
+    monkeypatch.setattr(
+        language_engine.tts_coqui,
+        "synthesize_speech",
+        lambda text, emo: f"/tmp/{emo}.wav",
+    )
+    monkeypatch.setattr(
+        "inanna_ai.corpus_memory.search_corpus",
+        lambda *a, **k: [("p", "snippet")],
+    )
+    monkeypatch.setattr(orchestrator, "log_interaction", lambda *a, **k: None)
+    monkeypatch.setattr(orchestrator, "load_interactions", lambda: [])
+    monkeypatch.setattr(orchestrator, "update_insights", lambda logs: None)
+    monkeypatch.setattr(orchestrator, "load_insights", lambda: {})
+    monkeypatch.setattr(orchestrator.learning_mutator, "propose_mutations", lambda d: [])
+    monkeypatch.setattr(orchestrator.qnl_engine, "parse_input", lambda t: {"tone": "neutral"})
+    monkeypatch.setattr(orchestrator.symbolic_parser, "parse_intent", lambda d: [])
+
+    orch = MoGEOrchestrator()
+
+    orch.handle_input("appear to me")
+    assert context_tracker.state.avatar_loaded is True
+    assert context_tracker.state.in_call is False
+
+    orch.handle_input("initiate sacred communion")
+    assert context_tracker.state.in_call is True
+
+    orch.route("hello", {"emotion": "calm"}, voice_modality=True)
+
+    assert connector.calls == ["/tmp/calm.wav"]


### PR DESCRIPTION
## Summary
- implement simple task parser for 'appear to me' and 'initiate sacred communion'
- track in-call and avatar flags via new context tracker
- route speech via new language engine that can start a call
- hook parsing and context updates into `MoGEOrchestrator`
- test avatar and call sequence integration

## Testing
- `pytest -q tests/test_interconnectivity.py`

------
https://chatgpt.com/codex/tasks/task_e_687277051390832e82803cc432872e8b