### PR TITLE
Add basic facial expression controller

### DIFF
--- a/core/facial_expression_controller.py
+++ b/core/facial_expression_controller.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Basic facial expression control utilities."""
+
+from typing import Dict, Tuple
+
+import numpy as np
+
+import emotional_state
+
+# Map emotions to simple RGB colours representing expressions.
+# In a real renderer these would correspond to blendshape weights
+# or bone pose targets.
+EMOTION_MAP: Dict[str, Tuple[int, int, int]] = {
+    "joy": (255, 215, 0),  # golden glow
+    "anger": (255, 0, 0),  # red tint
+    "sadness": (0, 0, 255),  # blue tint
+    "neutral": (128, 128, 128),
+}
+
+def get_current_expression() -> Tuple[int, int, int]:
+    """Return the expression colour for the last recorded emotion."""
+    emotion = emotional_state.get_last_emotion() or "neutral"
+    return EMOTION_MAP.get(emotion, EMOTION_MAP["neutral"])
+
+def apply_expression(frame: np.ndarray, emotion: str | None) -> np.ndarray:
+    """Return ``frame`` modified according to ``emotion``."""
+    colour = EMOTION_MAP.get(emotion or "neutral", EMOTION_MAP["neutral"])
+    modified = frame.copy()
+    modified[:8, :8] = np.array(colour, dtype=np.uint8)
+    return modified
+
+__all__ = ["get_current_expression", "apply_expression"]

--- a/core/video_engine.py
+++ b/core/video_engine.py
@@ -9,6 +9,9 @@ import logging
 import numpy as np
 import tomllib
 
+from .facial_expression_controller import apply_expression
+import emotional_state
+
 try:  # pragma: no cover - optional dependency
     import mediapipe as mp
 except Exception:  # pragma: no cover - optional dependency
@@ -56,6 +59,8 @@ def generate_avatar_stream() -> Iterator[np.ndarray]:
         while True:
             frame = np.zeros((64, 64, 3), dtype=np.uint8)
             frame[:] = color
+            emotion = emotional_state.get_last_emotion()
+            frame = apply_expression(frame, emotion)
             if mesh is not None:
                 # Feed dummy frame to mediapipe to update landmarks
                 _ = mesh.process(frame)

--- a/tests/test_emotion_loop.py
+++ b/tests/test_emotion_loop.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core import facial_expression_controller as fec
+
+
+def test_apply_expression_modifies_frame():
+    frame = np.zeros((16, 16, 3), dtype=np.uint8)
+    modified = fec.apply_expression(frame, "joy")
+    assert np.any(modified != frame)


### PR DESCRIPTION
## Summary
- implement `facial_expression_controller` with simple emotion mapping
- apply expressions in `video_engine.generate_avatar_stream`
- test expression application logic

## Testing
- `pytest tests/test_emotion_loop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68727d1c3728832ea77424dd02ecb65e