### PR TITLE
Improve avatar emotion handling

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,7 +5,8 @@ import numpy as np
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from core import video_engine
+from core import video_engine, context_tracker
+import emotional_state
 
 
 def test_generate_one_frame():
@@ -13,3 +14,30 @@ def test_generate_one_frame():
     frame = next(stream)
     assert isinstance(frame, np.ndarray)
     assert frame.ndim == 3 and frame.shape[2] == 3
+
+
+def test_expression_gated_by_avatar(monkeypatch):
+    called = {"n": 0}
+
+    def fake_apply(frame, emotion):
+        called["n"] += 1
+        return frame
+
+    monkeypatch.setattr(video_engine, "apply_expression", fake_apply)
+    monkeypatch.setattr(emotional_state, "get_last_emotion", lambda: "joy")
+    monkeypatch.setattr(context_tracker.state, "avatar_loaded", False)
+
+    stream = video_engine.start_stream()
+    next(stream)
+    assert called["n"] == 0
+
+
+def test_emotion_changes_frame(monkeypatch):
+    emotions = iter(["joy", "anger"])
+    monkeypatch.setattr(emotional_state, "get_last_emotion", lambda: next(emotions))
+    monkeypatch.setattr(context_tracker.state, "avatar_loaded", True)
+
+    stream = video_engine.start_stream()
+    frame1 = next(stream)
+    frame2 = next(stream)
+    assert np.any(frame1 != frame2)


### PR DESCRIPTION
## Summary
- update video engine to apply emotions only when avatar is loaded
- test gating logic for avatar expressions
- verify that different emotions produce distinct frames

## Testing
- `pytest tests/test_video.py tests/test_emotion_loop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687288bbf148832ebeadc576534c8158