### PR TITLE
Add reflection loop avatar test fixture

### DIFF
--- a/tests/test_emotion_loop.py
+++ b/tests/test_emotion_loop.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
+import types
+
 import numpy as np
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -10,6 +13,25 @@ from tools import reflection_loop
 from core import self_correction_engine
 import emotional_state
 from core import video_engine
+from core import context_tracker
+
+
+@pytest.fixture()
+def avatar_ready(monkeypatch, mock_emotion_state):
+    """Prepare avatar state and stub heavy dependencies."""
+    stub_cv2 = types.SimpleNamespace(
+        cvtColor=lambda f, c: f,
+        COLOR_RGB2BGR=0,
+    )
+    monkeypatch.setitem(sys.modules, "cv2", stub_cv2)
+    monkeypatch.setitem(sys.modules, "mediapipe", types.ModuleType("mediapipe"))
+
+    monkeypatch.setattr(context_tracker.state, "avatar_loaded", True)
+    emotional_state.set_last_emotion("joy")
+
+    frames = iter([np.zeros((1, 1, 3), dtype=np.uint8)])
+    monkeypatch.setattr(video_engine, "start_stream", lambda: frames)
+    return frames
 
 
 def test_reflection_loop_adjusts(monkeypatch):
@@ -54,3 +76,19 @@ def test_apply_expression_modifies_frame():
     frame = np.zeros((16, 16, 3), dtype=np.uint8)
     modified = fec.apply_expression(frame, "joy")
     assert np.any(modified != frame)
+
+
+def test_run_loop_uses_avatar_fixture(avatar_ready, monkeypatch):
+    monkeypatch.setattr(reflection_loop, "detect_expression", lambda f: "anger")
+    monkeypatch.setattr(reflection_loop, "load_thresholds", lambda: {"joy": 0.3})
+
+    captured = {}
+
+    def fake_adjust(detected, intended, tol):
+        captured["args"] = (detected, intended, tol)
+
+    monkeypatch.setattr(self_correction_engine, "adjust", fake_adjust)
+
+    reflection_loop.run_reflection_loop(iterations=1)
+
+    assert captured["args"] == ("anger", "joy", 0.3)


### PR DESCRIPTION
## Summary
- create `avatar_ready` fixture for reflection loop
- call `run_reflection_loop` through new test to verify adjust logic

## Testing
- `pytest tests/test_emotion_loop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687289b197e8832e9c19c29c81e8693c