### PR TITLE
Add StateTransitionEngine

### DIFF
--- a/state_transition_engine.py
+++ b/state_transition_engine.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Simple finite state engine based on emotional cues."""
+
+from typing import List
+
+from inanna_ai import emotion_analysis
+
+
+class StateTransitionEngine:
+    """Track ritual activation state."""
+
+    STATES = ("dormant", "active", "ritual")
+
+    def __init__(self) -> None:
+        self._state = "dormant"
+        self._history: List[str] = []
+
+    def _detect_emotion(self, text: str) -> str:
+        lowered = text.lower()
+        for key in emotion_analysis.EMOTION_ARCHETYPES:
+            if key in lowered:
+                return key
+        return "neutral"
+
+    def _recent_ritual_cues(self) -> bool:
+        return any("ritual" in e.lower() for e in self._history[-3:])
+
+    def update_state(self, event: str) -> str:
+        """Update and return current state based on ``event`` text."""
+        self._history.append(event)
+        if len(self._history) > 5:
+            self._history.pop(0)
+        emotion = self._detect_emotion(event)
+        weight = emotion_analysis.emotion_weight(emotion)
+        lowered = event.lower()
+        if "ritual" in lowered or self._recent_ritual_cues():
+            self._state = "ritual"
+        elif "activate" in lowered or "start" in lowered or weight >= 0.5:
+            self._state = "active"
+        elif weight < 0.3:
+            self._state = "dormant"
+        return self._state
+
+    def current_state(self) -> str:
+        """Return the current state."""
+        return self._state
+
+
+__all__ = ["StateTransitionEngine"]

--- a/tests/test_crown_prompt_orchestrator.py
+++ b/tests/test_crown_prompt_orchestrator.py
@@ -30,6 +30,7 @@ def test_basic_flow(monkeypatch):
     assert result["text"].startswith("glm:")
     assert result["model"] == "glm"
     assert "hi" in glm.seen
+    assert result["state"] == "dormant"
 
 
 def test_servant_invocation(monkeypatch):
@@ -38,4 +39,14 @@ def test_servant_invocation(monkeypatch):
     result = crown_prompt_orchestrator("how do things work?", glm)
     assert result["text"] == "ds:how do things work?"
     assert result["model"] == "deepseek"
+
+
+def test_state_engine_integration(monkeypatch):
+    glm = DummyGLM()
+    monkeypatch.setattr(
+        "crown_prompt_orchestrator.load_interactions",
+        lambda limit=3: [],
+    )
+    result = crown_prompt_orchestrator("begin the ritual", glm)
+    assert result["state"] == "ritual"
 

--- a/tests/test_state_transition_engine.py
+++ b/tests/test_state_transition_engine.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from state_transition_engine import StateTransitionEngine
+
+
+def test_state_transitions():
+    ste = StateTransitionEngine()
+    assert ste.current_state() == "dormant"
+    ste.update_state("I feel joy today")
+    assert ste.current_state() == "active"
+    ste.update_state("begin the ritual now")
+    assert ste.current_state() == "ritual"


### PR DESCRIPTION
## Summary
- create `StateTransitionEngine` to track ritual activation
- integrate engine into `crown_prompt_orchestrator`
- extend orchestrator tests and add new engine tests

## Testing
- `pytest -q tests/test_crown_prompt_orchestrator.py tests/test_state_transition_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6872982c2320832e8668a3e03796e51c