### PR TITLE
Add docs for Crown console and configuration

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -286,3 +286,22 @@ EOF
 
 `verify_integrity()` recomputes the SHA3‑256 hash and compares it to the stored
 value, ensuring the grid and its signature still match.
+
+## Crown Agent Console
+
+Launch the main GLM service and interactive console using the helper script
+`crown_model_launcher.sh`. The script loads `secrets.env`, ensures the
+GLM‑4.1V‑9B weights are present and starts a local API compatible with the
+`GLMIntegration` class.
+
+```bash
+./crown_model_launcher.sh
+```
+
+Once the service is running you can start the REPL:
+
+```bash
+python console_interface.py
+```
+
+The prompt `crown>` accepts natural language and `/exit` quits the session.

--- a/docs/CROWN_OVERVIEW.md
+++ b/docs/CROWN_OVERVIEW.md
@@ -1,0 +1,34 @@
+# Crown Agent Overview
+
+The diagram below shows how the main components interact when using the console.
+
+```
++--------------------+
+|    Crown Console   |
++---------+----------+
+          |
+          v
++---------+----------+
+|   Crown Agent      |
+| (GLMIntegration)   |
++---------+----------+
+          |
+          v
++---------+----------+
+| State Transition   |
+| Engine             |
++---------+----------+
+          |
+     +----+----+
+     |         |
+     v         v
++--------+ +---------------+
+|  GLM   | | Servant Models|
+| 4.1V   | | (DeepSeek etc)|
++--------+ +---------------+
+```
+
+User commands enter through the **Crown Console**. The **Crown Agent** sends
+requests to the GLM service and keeps recent history in memory. The
+**State Transition Engine** tracks ritual phrases and emotional cues. It may
+delegate a prompt to one of the registered servant models when appropriate.

--- a/docs/LLM_MODELS.md
+++ b/docs/LLM_MODELS.md
@@ -73,3 +73,25 @@ weight for each model using these scores. Faster and more relevant replies
 increase a model's weight while slower or incoherent ones reduce it. Model
 choice multiplies the heuristic score by the current weight, allowing the system
 to favour consistently strong performers over time.
+
+## Configuration
+
+The Crown agent loads settings from `config/INANNA_CORE.yaml`. Each option can
+be overridden with environment variables:
+
+- `GLM_API_URL` – URL of the GLM service used by `GLMIntegration`.
+- `GLM_API_KEY` – API key for that service.
+- `MODEL_PATH` – local path to the GLM‑4.1V‑9B weights.
+- `MEMORY_DIR` – directory holding `vector_memory/` and `chroma/`.
+- `DEEPSEEK_URL` – optional endpoint for the DeepSeek servant model.
+- `MISTRAL_URL` – optional endpoint for the Mistral servant model.
+
+Example overrides:
+
+```bash
+export GLM_API_URL=http://localhost:8001
+export MEMORY_DIR=/data/spiral_memory
+```
+
+Running `./crown_model_launcher.sh` reads `secrets.env` and starts a compatible
+GLM service if the weights are present.


### PR DESCRIPTION
## Summary
- document Crown Agent launcher and console in README_OPERATOR
- describe configuration options for servant models and GLM service
- add a new overview diagram of the Crown console architecture

## Testing
- `pytest tests/test_crown_initialization.py::test_initialize_crown -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68729dd0db2c832eabdc49c75a020990