### PR TITLE
Add reflection loop to orchestrator

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -10,6 +10,7 @@ from collections import deque
 import soundfile as sf
 from time import perf_counter
 import threading
+import logging
 
 try:  # pragma: no cover - optional dependency
     from sentence_transformers import SentenceTransformer
@@ -34,6 +35,9 @@ import training_guide
 from corpus_memory_logging import log_interaction, load_interactions
 from insight_compiler import update_insights, load_insights
 import learning_mutator
+from tools import reflection_loop
+
+logger = logging.getLogger(__name__)
 
 
 class MoGEOrchestrator:
@@ -273,6 +277,11 @@ class MoGEOrchestrator:
         result = self.route(text, emotion_data, qnl_data=qnl_data)
         if self._active_layer_name:
             emotional_state.set_current_layer(self._active_layer_name)
+        if context_tracker.state.avatar_loaded:
+            try:
+                reflection_loop.run_reflection_loop(iterations=1)
+            except Exception:  # pragma: no cover - safeguard
+                logger.exception("reflection loop failed")
         return result
 
 

--- a/tests/test_interconnectivity.py
+++ b/tests/test_interconnectivity.py
@@ -47,6 +47,7 @@ def test_avatar_and_call_sequence(monkeypatch):
     monkeypatch.setattr(orchestrator.learning_mutator, "propose_mutations", lambda d: [])
     monkeypatch.setattr(orchestrator.qnl_engine, "parse_input", lambda t: {"tone": "neutral"})
     monkeypatch.setattr(orchestrator.symbolic_parser, "parse_intent", lambda d: [])
+    monkeypatch.setattr(orchestrator.reflection_loop, "run_reflection_loop", lambda *a, **k: None)
 
     orch = MoGEOrchestrator()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -143,6 +143,7 @@ def test_handle_input_parses_and_routes(monkeypatch):
     monkeypatch.setattr(orchestrator.qnl_engine, "parse_input", fake_parse)
     monkeypatch.setattr(orchestrator.symbolic_parser, "parse_intent", fake_intent)
     monkeypatch.setattr(MoGEOrchestrator, "route", fake_route)
+    monkeypatch.setattr(orchestrator.reflection_loop, "run_reflection_loop", lambda *a, **k: None)
 
     orch = MoGEOrchestrator()
     out = orch.handle_input("hello")

--- a/tests/test_orchestrator_handle.py
+++ b/tests/test_orchestrator_handle.py
@@ -60,6 +60,7 @@ def test_handle_input_updates_mood(monkeypatch):
     monkeypatch.setattr(orchestrator.qnl_engine, 'parse_input', fake_parse)
     monkeypatch.setattr(orchestrator.symbolic_parser, 'parse_intent', fake_intent)
     monkeypatch.setattr(MoGEOrchestrator, 'route', fake_route)
+    monkeypatch.setattr(orchestrator.reflection_loop, 'run_reflection_loop', lambda *a, **k: None)
 
     orch = MoGEOrchestrator()
     joy_before = orch.mood_state.get('joy', 0.0)
@@ -127,6 +128,7 @@ def test_dynamic_layer_selection(monkeypatch):
     monkeypatch.setattr(orchestrator, "update_insights", lambda logs: None)
     monkeypatch.setattr(orchestrator, "load_insights", lambda: {})
     monkeypatch.setattr(orchestrator.learning_mutator, "propose_mutations", lambda d: [])
+    monkeypatch.setattr(orchestrator.reflection_loop, "run_reflection_loop", lambda *a, **k: None)
 
     orch = MoGEOrchestrator()
     result = orch.handle_input("hello")
@@ -148,6 +150,7 @@ def test_invocation_task_sequence(monkeypatch):
     monkeypatch.setattr(orchestrator, "ritual_action_sequence", lambda sym, emo: ["open portal"])
     monkeypatch.setattr(orchestrator.invocation_engine, "invoke", lambda t, o: [["weave sound"]])
     monkeypatch.setattr(orchestrator.invocation_engine, "_extract_symbols", lambda t: "☉")
+    monkeypatch.setattr(orchestrator.reflection_loop, "run_reflection_loop", lambda *a, **k: None)
 
     orch = MoGEOrchestrator()
     orch.handle_input("∴")
@@ -182,6 +185,7 @@ def test_invocation_logging(monkeypatch, glyph_input, tmp_path):
 
     monkeypatch.setattr(orchestrator.invocation_engine, "invoke", fake_invoke)
     monkeypatch.setattr(orchestrator.invocation_engine, "_extract_symbols", lambda t: "☉")
+    monkeypatch.setattr(orchestrator.reflection_loop, "run_reflection_loop", lambda *a, **k: None)
 
     records = {}
 

--- a/tools/reflection_loop.py
+++ b/tools/reflection_loop.py
@@ -58,9 +58,17 @@ def run_reflection_loop(iterations: int = 10) -> None:
             frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
         detected = detect_expression(frame)
         intended = emotional_state.get_last_emotion() or "neutral"
+        logger.debug("reflection detected=%s intended=%s", detected, intended)
         if detected != intended:
             tol = thresholds.get(intended, thresholds.get("default", 0.0))
+            logger.info(
+                "mismatch detected: %s vs %s (tol %.3f)",
+                detected,
+                intended,
+                tol,
+            )
             self_correction_engine.adjust(detected, intended, tol)
+            logger.info("correction issued from %s to %s", detected, intended)
 
 
 __all__ = ["run_reflection_loop", "detect_expression", "load_thresholds"]


### PR DESCRIPTION
## Summary
- run tools.reflection_loop from orchestrator after routing
- log mismatches and corrections in reflection_loop
- patch tests to stub the reflection loop

## Testing
- `pytest tests/test_orchestrator.py::test_handle_input_parses_and_routes -q`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'Generator')*

------
https://chatgpt.com/codex/tasks/task_e_6872a0acbebc832e84f1810cd00930e5