### PR TITLE
Add GLM shell helper

### DIFF
--- a/glm_shell.py
+++ b/glm_shell.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Send shell commands to the Crown GLM endpoint.
+
+Usage:
+    python glm_shell.py "<command>"
+"""
+
+import argparse
+
+from init_crown_agent import initialize_crown
+
+
+def send_command(command: str) -> str:
+    """Return GLM response for ``command`` sent as a shell instruction."""
+    glm = initialize_crown()
+    prompt = f"[shell]{command}"
+    return glm.complete(prompt)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="glm_shell")
+    parser.add_argument("command", help="Shell command to execute")
+    args = parser.parse_args(argv)
+    print(send_command(args.command))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_glm_shell.py
+++ b/tests/test_glm_shell.py
@@ -1,0 +1,29 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import importlib
+
+
+class DummyGLM:
+    def __init__(self):
+        self.prompts = []
+
+    def complete(self, prompt: str, quantum_context: str | None = None) -> str:
+        self.prompts.append((prompt, quantum_context))
+        return "response"
+
+
+def test_send_command(monkeypatch):
+    dummy = DummyGLM()
+    mod = ModuleType("init_crown_agent")
+    mod.initialize_crown = lambda: dummy
+    monkeypatch.setitem(sys.modules, "init_crown_agent", mod)
+    glm_shell = importlib.import_module("glm_shell")
+    out = glm_shell.send_command("ls -la")
+    assert out == "response"
+    assert dummy.prompts == [("[shell]ls -la", None)]
+


### PR DESCRIPTION
## Summary
- add `glm_shell.py` for sending single commands to the GLM endpoint
- test new helper

## Testing
- `pytest tests/test_glm_shell.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a3e2821c832ebfc2e9cf0d23725c