### PR TITLE
Add GLM command API endpoint

### DIFF
--- a/README_OPERATOR.md
+++ b/README_OPERATOR.md
@@ -305,3 +305,16 @@ python console_interface.py
 ```
 
 The prompt `crown>` accepts natural language and `/exit` quits the session.
+
+## HTTP Interface
+
+`server.py` exposes a small FastAPI application with a `/glm-command` endpoint.
+Start the server and invoke it with `curl`:
+
+```bash
+curl -X POST http://localhost:8000/glm-command \
+     -H 'Content-Type: application/json' \
+     -d '{"command": "ls"}'
+```
+
+The JSON response contains the GLM result under `result`.

--- a/server.py
+++ b/server.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+from glm_shell import send_command
 
 app = FastAPI()
 
@@ -16,3 +19,16 @@ def health_check() -> dict[str, str]:
 def readiness_check() -> dict[str, str]:
     """Return service readiness status."""
     return {"status": "ready"}
+
+
+class ShellCommand(BaseModel):
+    """Payload for ``/glm-command``."""
+
+    command: str
+
+
+@app.post("/glm-command")
+def glm_command(cmd: ShellCommand) -> dict[str, str]:
+    """Execute ``cmd.command`` via the GLM shell and return the result."""
+    result = send_command(cmd.command)
+    return {"result": result}

--- a/tests/test_glm_shell.py
+++ b/tests/test_glm_shell.py
@@ -22,6 +22,7 @@ def test_send_command(monkeypatch):
     mod = ModuleType("init_crown_agent")
     mod.initialize_crown = lambda: dummy
     monkeypatch.setitem(sys.modules, "init_crown_agent", mod)
+    sys.modules.pop("glm_shell", None)
     glm_shell = importlib.import_module("glm_shell")
     out = glm_shell.send_command("ls -la")
     assert out == "response"


### PR DESCRIPTION
## Summary
- extend FastAPI server with `/glm-command`
- expose shell command endpoint by calling `send_command`
- patch tests for the new route
- reload `glm_shell` module in its unit test
- document the `curl` example in the operator guide

## Testing
- `pytest tests/test_server.py tests/test_glm_shell.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a5385ab4832ea539a58154f73686