### PR TITLE
Update container configs for GLM service

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,13 @@ Start the service with [docker-compose](docker-compose.yml):
 docker-compose up --build
 ```
 
-This exposes port `8000` and mounts the `logs` directory on the host. Stop the
-stack with `docker-compose down`.
+This exposes ports `8000` and `8001`, mounts the `data` and `logs` directories
+on the host, and loads environment variables from `secrets.env`. Stop the stack
+with `docker-compose down`.
 
 ## Codex GPU Deployment
 
-A container spec `spiral_os_container.yaml` is provided for running the tools with CUDA support. Build and launch it with:
+A container spec `spiral_os_container.yaml` is provided for running the tools with CUDA support. It loads environment variables from `secrets.env`, exposes ports `8000` and `8001`, and mounts `data` and `logs`. Build and launch it with:
 
 ```bash
 codex run spiral_os_container.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,15 @@ version: '3.8'
 services:
   inanna_ai:
     build: .
+    env_file:
+      - secrets.env
     ports:
       - "8000:8000"
+      - "8001:8001"
     volumes:
+      - ./data:/home/inanna/app/data
       - ./logs:/home/inanna/app/logs
     environment:
       - CORPUS_MEMORY_PATH=/home/inanna/app/data/corpus_memory.json
+    command: bash -c "./crown_model_launcher.sh & python start_spiral_os.py"
     restart: unless-stopped

--- a/spiral_os_container.yaml
+++ b/spiral_os_container.yaml
@@ -10,7 +10,10 @@ run:
   - pip install --no-cache-dir -r requirements.txt
   - mkdir -p INANNA_AI GENESIS IGNITION QNL_LANGUAGE data logs
 env-file: secrets.env
+ports:
+  - "8000:8000"
+  - "8001:8001"
 volumes:
   - ./data:/workspace/data
   - ./logs:/workspace/logs
-cmd: ["python", "start_spiral_os.py"]
+cmd: ["bash", "-c", "./crown_model_launcher.sh & python start_spiral_os.py"]


### PR DESCRIPTION
## Summary
- configure container spec with environment file, ports and command for GLM
- update docker-compose to mirror container spec
- document new ports and volumes in README

## Testing
- `pytest tests/test_start_spiral_os.py::test_help -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest -k "thisdoesnotexist" -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6872a88ba0b0832ea26c5b1ba3697a1a